### PR TITLE
Implement pico_stack_recv_zerocopy_ext_buffer

### DIFF
--- a/include/pico_frame.h
+++ b/include/pico_frame.h
@@ -8,8 +8,9 @@
 #include "pico_config.h"
 
 
-#define PICO_FRAME_FLAG_BCAST   (0x01)
-#define PICO_FRAME_FLAG_SACKED  (0x80)
+#define PICO_FRAME_FLAG_BCAST      (0x01)
+#define PICO_FRAME_FLAG_EXT_BUFFER (0x02)
+#define PICO_FRAME_FLAG_SACKED     (0x80)
 #define IS_BCAST(f) ((f->flags & PICO_FRAME_FLAG_BCAST) == PICO_FRAME_FLAG_BCAST)
 
 
@@ -83,7 +84,7 @@ void pico_frame_discard(struct pico_frame *f);
 struct pico_frame *pico_frame_copy(struct pico_frame *f);
 struct pico_frame *pico_frame_deepcopy(struct pico_frame *f);
 struct pico_frame *pico_frame_alloc(uint32_t size);
-struct pico_frame *pico_frame_alloc_skeleton(uint32_t size);
+struct pico_frame *pico_frame_alloc_skeleton(uint32_t size, int32_t ext_buffer);
 int pico_frame_skeleton_set_buffer(struct pico_frame *f, void *buf);
 uint16_t pico_checksum(void *inbuf, uint32_t len);
 uint16_t pico_dualbuffer_checksum(void *b1, uint32_t len1, void *b2, uint32_t len2);

--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -38,7 +38,7 @@ int32_t pico_ethernet_receive(struct pico_frame *f);
  */
 int32_t pico_stack_recv(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len);
-
+int32_t pico_stack_recv_zerocopy_ext_buffer(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 
 /* ===== SENDIING FUNCTIONS (from socket down to dev) ===== */
 

--- a/stack/pico_frame.c
+++ b/stack/pico_frame.c
@@ -28,7 +28,9 @@ void pico_frame_discard(struct pico_frame *f)
         dbg("Discarded buffer @%p, caller: %p\n", f->buffer, __builtin_return_address(3));
         dbg("DEBUG MEMORY: %d frames in use.\n", --n_frames_allocated);
 #endif
-        PICO_FREE(f->buffer);
+        if (! (f->flags & PICO_FRAME_FLAG_EXT_BUFFER))
+            PICO_FREE(f->buffer);
+
         if (f->info)
             PICO_FREE(f->info);
     }
@@ -57,7 +59,7 @@ struct pico_frame *pico_frame_copy(struct pico_frame *f)
 }
 
 
-static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy)
+static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy, int ext_buffer)
 {
     struct pico_frame *p = PICO_ZALLOC(sizeof(struct pico_frame));
     if (!p)
@@ -75,7 +77,7 @@ static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy)
 
     p->usage_count = PICO_ZALLOC(sizeof(uint32_t));
     if (!p->usage_count) {
-        if (p->buffer)
+        if (p->buffer && !ext_buffer)
             PICO_FREE(p->buffer);
 
         PICO_FREE(p);
@@ -89,6 +91,10 @@ static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy)
     p->start = p->buffer;
     p->len = p->buffer_len;
     *p->usage_count = 1;
+
+    if (ext_buffer)
+        p->flags = PICO_FRAME_FLAG_EXT_BUFFER;
+
 #ifdef PICO_SUPPORT_DEBUG_MEMORY
     dbg("Allocated buffer @%p, len= %d caller: %p\n", p->buffer, p->buffer_len, __builtin_return_address(2));
     dbg("DEBUG MEMORY: %d frames in use.\n", ++n_frames_allocated);
@@ -98,12 +104,12 @@ static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy)
 
 struct pico_frame *pico_frame_alloc(uint32_t size)
 {
-    return pico_frame_do_alloc(size, 0);
+    return pico_frame_do_alloc(size, 0, 0);
 }
 
-struct pico_frame *pico_frame_alloc_skeleton(uint32_t size)
+struct pico_frame *pico_frame_alloc_skeleton(uint32_t size, int32_t ext_buffer)
 {
-    return pico_frame_do_alloc(size, 1);
+    return pico_frame_do_alloc(size, 1, ext_buffer);
 }
 
 int pico_frame_skeleton_set_buffer(struct pico_frame *f, void *buf)

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -575,14 +575,14 @@ int32_t pico_stack_recv(struct pico_device *dev, uint8_t *buffer, uint32_t len)
     return ret;
 }
 
-int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len)
+static int32_t _pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len, int32_t ext_buffer)
 {
     struct pico_frame *f;
     int ret;
     if (len <= 0)
         return -1;
 
-    f = pico_frame_alloc_skeleton(len);
+    f = pico_frame_alloc_skeleton(len, ext_buffer);
     if (!f)
     {
         dbg("Cannot alloc incoming frame!\n");
@@ -604,6 +604,14 @@ int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint3
     }
 
     return ret;
+}
+
+int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len) {
+	return _pico_stack_recv_zerocopy(dev, buffer, len, 0);
+}
+
+int32_t pico_stack_recv_zerocopy_ext_buffer(struct pico_device *dev, uint8_t *buffer, uint32_t len) {
+	return _pico_stack_recv_zerocopy(dev, buffer, len, 1);
 }
 
 int32_t pico_sendto_dev(struct pico_frame *f)


### PR DESCRIPTION
This patch implement the function `pico_stack_recv_zerocopy_ext_buffer` which allows to use zerocopy with an external buffer.
An external buffer is a buffer which is not allocated with `PICO_ZALLOC()`.
With this patch it is possible to use (for example) a circular ring managed by the application.
