### PR TITLE
stack/pico_socket.c: fix -Wmissing-prototypes warnings

### DIFF
--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -148,7 +148,7 @@ static int socket_cmp(void *ka, void *kb)
 
 #define INIT_SOCKPORT { {&LEAF, socket_cmp}, 0, 0 }
 
-int sockport_cmp(void *ka, void *kb)
+static int sockport_cmp(void *ka, void *kb)
 {
     struct pico_sockport *a = ka, *b = kb;
     if (a->number < b->number)
@@ -755,7 +755,7 @@ int pico_socket_write(struct pico_socket *s, const void *buf, int len)
     return pico_socket_write_attempt(s, buf, len);
 }
 
-uint16_t pico_socket_high_port(uint16_t proto)
+static uint16_t pico_socket_high_port(uint16_t proto)
 {
     uint16_t port;
     if (0 ||


### PR DESCRIPTION
Adding -Wmissing-prototypes to CFLAGS leads to warnings in
pico_socket.c:

stack/pico_socket.c:151:5: warning: no previous prototype for
‘sockport_cmp’ [-Wmissing-prototypes]
 int sockport_cmp(void *ka, void *kb)
     ^
stack/pico_socket.c:758:10: warning: no previous prototype for
‘pico_socket_high_port’ [-Wmissing-prototypes]
 uint16_t pico_socket_high_port(uint16_t proto)
          ^

This patch fixes the problem.

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>