### PR TITLE
Seperation of ethernet from stack

### DIFF
--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -16,14 +16,42 @@
 
 /* ===== RECEIVING FUNCTIONS (from dev up to socket) ===== */
 
-/* TRANSPORT LEVEL */
-/* interface towards network */
+//===----------------------------------------------------------------------===//
+//  TRANSPORT LAYER
+//===----------------------------------------------------------------------===//
+
+/* From dev up to socket */
 int32_t pico_transport_receive(struct pico_frame *f, uint8_t proto);
 
-/* NETWORK LEVEL */
-/* interface towards ethernet */
+//===----------------------------------------------------------------------===//
+//  NETWORK LAYER
+//===----------------------------------------------------------------------===//
+
+/* From socket down to dev */
+int32_t pico_network_send(struct pico_frame *f);
+
+/* From dev up to socket */
 int32_t pico_network_receive(struct pico_frame *f);
 
+//===----------------------------------------------------------------------===//
+//  DATALINK LAYER
+//===----------------------------------------------------------------------===//
+
+/* From socket down to dev */
+int pico_datalink_send(struct pico_frame *f);
+
+/* From dev up to socket */
+int pico_datalink_receive(struct pico_frame *f);
+
+/* Enqueues the frame in the device-queue. However, before the frame is
+ * actually send to the device itself, it may be possible that the frame passes
+ * through the datalink-layer first.
+ */
+int32_t pico_sendto_dev(struct pico_frame *f);
+
+//===----------------------------------------------------------------------===//
+//  PHYSICAL LAYER
+//===----------------------------------------------------------------------===//
 
 /* LOWEST LEVEL: interface towards devices. */
 /* Device driver will call this function which returns immediately.
@@ -35,26 +63,6 @@ int32_t pico_stack_recv(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy_ext_buffer(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy_ext_buffer_notify(struct pico_device *dev, uint8_t *buffer, uint32_t len, void (*notify_free)(uint8_t *buffer));
-
-/* ===== SENDING FUNCTIONS (from socket down to dev) ===== */
-
-int32_t pico_network_send(struct pico_frame *f);
-int32_t pico_sendto_dev(struct pico_frame *f);
-
-#ifdef PICO_SUPPORT_ETH
-int32_t pico_ethernet_send(struct pico_frame *f);
-
-/* The pico_ethernet_receive() function is used by
- * those devices supporting ETH in order to push packets up
- * into the stack.
- */
-/* DATALINK LEVEL */
-int32_t pico_ethernet_receive(struct pico_frame *f);
-#else
-/* When ETH is not supported by the stack... */
-#   define pico_ethernet_send(f)    (-1)
-#   define pico_ethernet_receive(f) (-1)
-#endif
 
 /* ----- Initialization ----- */
 int pico_stack_init(void);

--- a/modules/pico_arp.c
+++ b/modules/pico_arp.c
@@ -7,13 +7,13 @@
    Authors: Daniele Lacamera
  *********************************************************************/
 
-
 #include "pico_config.h"
 #include "pico_arp.h"
 #include "pico_tree.h"
 #include "pico_ipv4.h"
 #include "pico_device.h"
 #include "pico_stack.h"
+#include "pico_ethernet.h"
 
 extern const uint8_t PICO_ETHADDR_ALL[6];
 #define PICO_ARP_TIMEOUT 600000llu

--- a/modules/pico_ethernet.c
+++ b/modules/pico_ethernet.c
@@ -1,0 +1,377 @@
+/*********************************************************************
+   PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
+   See LICENSE and COPYING for usage.
+
+   .
+
+   Authors: Daniele Lacamera
+ *********************************************************************/
+
+#include "pico_config.h"
+#include "pico_stack.h"
+#include "pico_ipv4.h"
+#include "pico_ipv6.h"
+#include "pico_icmp4.h"
+#include "pico_icmp6.h"
+#include "pico_arp.h"
+#include "pico_ethernet.h"
+
+#define IS_LIMITED_BCAST(f) (((struct pico_ipv4_hdr *) f->net_hdr)->dst.addr == PICO_IP4_BCAST)
+
+const uint8_t PICO_ETHADDR_ALL[6] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+# define PICO_SIZE_MCAST 3
+static const uint8_t PICO_ETHADDR_MCAST[6] = {
+    0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
+};
+
+#ifdef PICO_SUPPORT_IPV6
+# define PICO_SIZE_MCAST6 2
+static const uint8_t PICO_ETHADDR_MCAST6[6] = {
+    0x33, 0x33, 0x00, 0x00, 0x00, 0x00
+};
+#endif
+
+#ifdef PICO_SUPPORT_ETH
+/* DATALINK LEVEL: interface from network to the device
+ * and vice versa.
+ */
+
+/* The pico_ethernet_receive() function is used by
+ * those devices supporting ETH in order to push packets up
+ * into the stack.
+ */
+
+static int destination_is_bcast(struct pico_frame *f)
+{
+    if (!f)
+        return 0;
+
+    if (IS_IPV6(f))
+        return 0;
+
+#ifdef PICO_SUPPORT_IPV4
+    else {
+        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+        return pico_ipv4_is_broadcast(hdr->dst.addr);
+    }
+#else
+    return 0;
+#endif
+}
+
+static int destination_is_mcast(struct pico_frame *f)
+{
+    int ret = 0;
+    if (!f)
+        return 0;
+
+#ifdef PICO_SUPPORT_IPV6
+    if (IS_IPV6(f)) {
+        struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *) f->net_hdr;
+        ret = pico_ipv6_is_multicast(hdr->dst.addr);
+    }
+
+#endif
+#ifdef PICO_SUPPORT_IPV4
+    else {
+        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+        ret = pico_ipv4_is_multicast(hdr->dst.addr);
+    }
+#endif
+
+    return ret;
+}
+
+#ifdef PICO_SUPPORT_IPV4
+static int32_t pico_ipv4_ethernet_receive(struct pico_frame *f)
+{
+    if (IS_IPV4(f)) {
+        pico_enqueue(pico_proto_ipv4.q_in, f);
+    } else {
+        (void)pico_icmp4_param_problem(f, 0);
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    return (int32_t)f->buffer_len;
+}
+#endif
+
+#ifdef PICO_SUPPORT_IPV6
+static int32_t pico_ipv6_ethernet_receive(struct pico_frame *f)
+{
+    if (IS_IPV6(f)) {
+        pico_enqueue(pico_proto_ipv6.q_in, f);
+    } else {
+        /* Wrong version for link layer type */
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    return (int32_t)f->buffer_len;
+}
+#endif
+
+static int32_t pico_eth_receive(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+
+#if (defined PICO_SUPPORT_IPV4) && (defined PICO_SUPPORT_ETH)
+    if (hdr->proto == PICO_IDETH_ARP)
+        return pico_arp_receive(f);
+#endif
+
+#if defined (PICO_SUPPORT_IPV4)
+    if (hdr->proto == PICO_IDETH_IPV4)
+        return pico_ipv4_ethernet_receive(f);
+#endif
+
+#if defined (PICO_SUPPORT_IPV6)
+    if (hdr->proto == PICO_IDETH_IPV6)
+        return pico_ipv6_ethernet_receive(f);
+#endif
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+static void pico_eth_check_bcast(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    /* Indicate a link layer broadcast packet */
+    if (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) == 0)
+        f->flags |= PICO_FRAME_FLAG_BCAST;
+}
+
+int32_t pico_ethernet_receive(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr;
+    if (!f || !f->dev || !f->datalink_hdr)
+    {
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    if ((memcmp(hdr->daddr, f->dev->eth->mac.addr, PICO_SIZE_ETH) != 0) &&
+        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST, PICO_SIZE_MCAST) != 0) &&
+#ifdef PICO_SUPPORT_IPV6
+        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST6, PICO_SIZE_MCAST6) != 0) &&
+#endif
+        (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) != 0))
+    {
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    pico_eth_check_bcast(f);
+    return pico_eth_receive(f);
+}
+
+static struct pico_eth *pico_ethernet_mcast_translate(struct pico_frame *f, uint8_t *pico_mcast_mac)
+{
+    struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+
+    /* place 23 lower bits of IP in lower 23 bits of MAC */
+    pico_mcast_mac[5] = (long_be(hdr->dst.addr) & 0x000000FFu);
+    pico_mcast_mac[4] = (uint8_t)((long_be(hdr->dst.addr) & 0x0000FF00u) >> 8u);
+    pico_mcast_mac[3] = (uint8_t)((long_be(hdr->dst.addr) & 0x007F0000u) >> 16u);
+
+    return (struct pico_eth *)pico_mcast_mac;
+}
+
+
+#ifdef PICO_SUPPORT_IPV6
+static struct pico_eth *pico_ethernet_mcast6_translate(struct pico_frame *f, uint8_t *pico_mcast6_mac)
+{
+    struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *)f->net_hdr;
+
+    /* first 2 octets are 0x33, last four are the last four of dst */
+    pico_mcast6_mac[5] = hdr->dst.addr[PICO_SIZE_IP6 - 1];
+    pico_mcast6_mac[4] = hdr->dst.addr[PICO_SIZE_IP6 - 2];
+    pico_mcast6_mac[3] = hdr->dst.addr[PICO_SIZE_IP6 - 3];
+    pico_mcast6_mac[2] = hdr->dst.addr[PICO_SIZE_IP6 - 4];
+
+    return (struct pico_eth *)pico_mcast6_mac;
+}
+#endif
+
+static int pico_ethernet_ipv6_dst(struct pico_frame *f, struct pico_eth *const dstmac)
+{
+    int retval = -1;
+    if (!dstmac)
+        return -1;
+
+    #ifdef PICO_SUPPORT_IPV6
+    if (destination_is_mcast(f)) {
+        uint8_t pico_mcast6_mac[6] = {
+            0x33, 0x33, 0x00, 0x00, 0x00, 0x00
+        };
+        pico_ethernet_mcast6_translate(f, pico_mcast6_mac);
+        memcpy(dstmac, pico_mcast6_mac, PICO_SIZE_ETH);
+        retval = 0;
+    } else {
+        struct pico_eth *neighbor = pico_ipv6_get_neighbor(f);
+        if (neighbor)
+        {
+            memcpy(dstmac, neighbor, PICO_SIZE_ETH);
+            retval = 0;
+        }
+    }
+
+    #else
+    (void)f;
+    pico_err = PICO_ERR_EPROTONOSUPPORT;
+    #endif
+    return retval;
+}
+
+
+/* Ethernet send, first attempt: try our own address.
+ * Returns 0 if the packet is not for us.
+ * Returns 1 if the packet is cloned to our own receive queue, so the caller can discard the original frame.
+ * */
+static int32_t pico_ethsend_local(struct pico_frame *f, struct pico_eth_hdr *hdr)
+{
+    if (!hdr)
+        return 0;
+
+    /* Check own mac */
+    if(!memcmp(hdr->daddr, hdr->saddr, PICO_SIZE_ETH)) {
+        struct pico_frame *clone = pico_frame_copy(f);
+        dbg("sending out packet destined for our own mac\n");
+        (void)pico_ethernet_receive(clone);
+        return 1;
+    }
+
+    return 0;
+}
+
+/* Ethernet send, second attempt: try bcast.
+ * Returns 0 if the packet is not bcast, so it will be handled somewhere else.
+ * Returns 1 if the packet is handled by the pico_device_broadcast() function, so it can be discarded.
+ * */
+static int32_t pico_ethsend_bcast(struct pico_frame *f)
+{
+    if (IS_LIMITED_BCAST(f)) {
+        (void)pico_device_broadcast(f); /* We can discard broadcast even if it's not sent. */
+        return 1;
+    }
+
+    return 0;
+}
+
+/* Ethernet send, third attempt: try unicast.
+ * If the device driver is busy, we return 0, so the stack won't discard the frame.
+ * In case of success, we can safely return 1.
+ */
+static int32_t pico_ethsend_dispatch(struct pico_frame *f)
+{
+    int ret = f->dev->send(f->dev, f->start, (int) f->len);
+    if (ret <= 0)
+        return 0; /* Failure to deliver! */
+    else {
+        return 1; /* Frame is in flight by now. */
+    }
+}
+
+
+
+
+/* This function looks for the destination mac address
+ * in order to send the frame being processed.
+ */
+
+int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
+{
+    struct pico_eth dstmac;
+    uint8_t dstmac_valid = 0;
+    uint16_t proto = PICO_IDETH_IPV4;
+
+#ifdef PICO_SUPPORT_IPV6
+    /* Step 1: If the frame has an IPv6 packet,
+     * destination address is taken from the ND tables
+     */
+    if (IS_IPV6(f)) {
+        if (pico_ethernet_ipv6_dst(f, &dstmac) < 0)
+        {
+            pico_ipv6_nd_postpone(f);
+            return 0; /* I don't care if frame was actually postponed. If there is no room in the ND table, discard safely. */
+        }
+
+        dstmac_valid = 1;
+        proto = PICO_IDETH_IPV6;
+    }
+    else
+#endif
+
+    /* In case of broadcast (IPV4 only), dst mac is FF:FF:... */
+    if (IS_BCAST(f) || destination_is_bcast(f))
+    {
+        memcpy(&dstmac, PICO_ETHADDR_ALL, PICO_SIZE_ETH);
+        dstmac_valid = 1;
+    }
+
+    /* In case of multicast, dst mac is translated from the group address */
+    else if (destination_is_mcast(f)) {
+        uint8_t pico_mcast_mac[6] = {
+            0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
+        };
+        pico_ethernet_mcast_translate(f, pico_mcast_mac);
+        memcpy(&dstmac, pico_mcast_mac, PICO_SIZE_ETH);
+        dstmac_valid = 1;
+    }
+
+#if (defined PICO_SUPPORT_IPV4)
+    else {
+        struct pico_eth *arp_get;
+        arp_get = pico_arp_get(f);
+        if (arp_get) {
+            memcpy(&dstmac, arp_get, PICO_SIZE_ETH);
+            dstmac_valid = 1;
+        } else {
+            /* At this point, ARP will discard the frame in any case.
+             * It is safe to return without discarding.
+             */
+            pico_arp_postpone(f);
+            return 0;
+            /* Same case as for IPv6 ... */
+        }
+
+    }
+#endif
+
+    /* This sets destination and source address, then pushes the packet to the device. */
+    if (dstmac_valid) {
+        struct pico_eth_hdr *hdr;
+        hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+        if ((f->start > f->buffer) && ((f->start - f->buffer) >= PICO_SIZE_ETHHDR))
+        {
+            f->start -= PICO_SIZE_ETHHDR;
+            f->len += PICO_SIZE_ETHHDR;
+            f->datalink_hdr = f->start;
+            hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+            memcpy(hdr->saddr, f->dev->eth->mac.addr, PICO_SIZE_ETH);
+            memcpy(hdr->daddr, &dstmac, PICO_SIZE_ETH);
+            hdr->proto = proto;
+        }
+
+        if (pico_ethsend_local(f, hdr) || pico_ethsend_bcast(f) || pico_ethsend_dispatch(f)) {
+            /* one of the above functions has delivered the frame accordingly. (returned != 0)
+             * It is safe to directly return success.
+             * */
+            return 0;
+        }
+    }
+
+    /* Failure: do not dequeue the frame, keep it for later. */
+    return -1;
+}
+
+#endif /* PICO_SUPPORT_ETH */
+
+

--- a/modules/pico_ethernet.h
+++ b/modules/pico_ethernet.h
@@ -1,0 +1,32 @@
+/*********************************************************************
+   PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
+   See LICENSE and COPYING for usage.
+
+   .
+
+   Authors: Daniele Lacamera
+ *********************************************************************/
+
+#ifndef INCLUDE_PICO_ETHERNET
+#define INCLUDE_PICO_ETHERNET
+
+#include "pico_config.h"
+#include "pico_frame.h"
+
+#ifdef PICO_SUPPORT_ETH
+int32_t pico_ethernet_send(struct pico_frame *f);
+
+/* The pico_ethernet_receive() function is used by
+ * those devices supporting ETH in order to push packets up
+ * into the stack.
+ */
+/* DATALINK LEVEL */
+int32_t pico_ethernet_receive(struct pico_frame *f);
+
+#else
+/* When ETH is not supported by the stack... */
+#   define pico_ethernet_send(f)    (-1)
+#   define pico_ethernet_receive(f) (-1)
+#endif
+
+#endif /* INCLUDE_PICO_ETHERNET */

--- a/modules/pico_ipv6_nd.c
+++ b/modules/pico_ipv6_nd.c
@@ -7,6 +7,7 @@
    Authors: Daniele Lacamera
  *********************************************************************/
 
+#include "pico_ethernet.h"
 #include "pico_config.h"
 #include "pico_tree.h"
 #include "pico_icmp6.h"

--- a/rules/eth.mk
+++ b/rules/eth.mk
@@ -1,2 +1,3 @@
 OPTIONS+=-DPICO_SUPPORT_ETH
 MOD_OBJ+=$(LIBBASE)modules/pico_arp.o
+MOD_OBJ+=$(LIBBASE)modules/pico_ethernet.o

--- a/stack/pico_device.c
+++ b/stack/pico_device.c
@@ -16,6 +16,7 @@
 #include "pico_ipv4.h"
 #include "pico_icmp6.h"
 #include "pico_eth.h"
+
 #define PICO_DEVICE_DEFAULT_MTU (1500)
 
 struct pico_devices_rr_info {
@@ -243,7 +244,7 @@ static int devloop_in(struct pico_device *dev, int loop_score)
         if (f) {
             if (dev->eth) {
                 f->datalink_hdr = f->buffer;
-                (void)pico_ethernet_receive(f);
+                (void)pico_datalink_receive(f);
             } else {
                 f->net_hdr = f->buffer;
                 pico_network_receive(f);
@@ -259,8 +260,8 @@ static int devloop_sendto_dev(struct pico_device *dev, struct pico_frame *f)
 {
 
     if (dev->eth) {
-        /* Ethernet: pass management of the frame to the pico_ethernet_send() rdv function */
-        return pico_ethernet_send(f);
+        /* Datalink: pass management of the frame to the pico_datalink_send() rdv function */
+        return pico_datalink_send(f);
     } else {
         /* non-ethernet: no post-processing needed */
         return (dev->send(dev, f->start, (int)f->len) <= 0); /* Return 0 upon success, which is dev->send() > 0 */

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -16,6 +16,7 @@
 #include "pico_addressing.h"
 #include "pico_dns_client.h"
 
+#include "pico_ethernet.h"
 #include "pico_olsr.h"
 #include "pico_aodv.h"
 #include "pico_eth.h"
@@ -29,24 +30,6 @@
 #include "pico_tcp.h"
 #include "pico_socket.h"
 #include "heap.h"
-
-#define IS_LIMITED_BCAST(f) (((struct pico_ipv4_hdr *) f->net_hdr)->dst.addr == PICO_IP4_BCAST)
-
-const uint8_t PICO_ETHADDR_ALL[6] = {
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff
-};
-
-# define PICO_SIZE_MCAST 3
-static const uint8_t PICO_ETHADDR_MCAST[6] = {
-    0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
-};
-
-#ifdef PICO_SUPPORT_IPV6
-# define PICO_SIZE_MCAST6 2
-static const uint8_t PICO_ETHADDR_MCAST6[6] = {
-    0x33, 0x33, 0x00, 0x00, 0x00, 0x00
-};
-#endif
 
 /* Mockables */
 #if defined UNIT_TEST
@@ -197,8 +180,10 @@ int pico_notify_pkt_too_big(struct pico_frame *f)
     return 0;
 }
 
+//===----------------------------------------------------------------------===//
+//  TRANSPORT LAYER
+//===----------------------------------------------------------------------===//
 
-/* Transport layer */
 MOCKABLE int32_t pico_transport_receive(struct pico_frame *f, uint8_t proto)
 {
     int32_t ret = -1;
@@ -267,7 +252,11 @@ int32_t pico_network_receive(struct pico_frame *f)
     return (int32_t)f->buffer_len;
 }
 
-/* Network layer: interface towards socket for frame sending */
+//===----------------------------------------------------------------------===//
+//  NETWORK LAYER
+//===----------------------------------------------------------------------===//
+
+/// Interface towards socket for frame sending
 int32_t pico_network_send(struct pico_frame *f)
 {
     if (!f || !f->sock || !f->sock->net) {
@@ -301,350 +290,6 @@ int pico_source_is_local(struct pico_frame *f)
 #endif
     return 0;
 }
-
-#ifdef PICO_SUPPORT_ETH
-/* DATALINK LEVEL: interface from network to the device
- * and vice versa.
- */
-
-/* The pico_ethernet_receive() function is used by
- * those devices supporting ETH in order to push packets up
- * into the stack.
- */
-
-static int destination_is_bcast(struct pico_frame *f)
-{
-    if (!f)
-        return 0;
-
-    if (IS_IPV6(f))
-        return 0;
-
-#ifdef PICO_SUPPORT_IPV4
-    else {
-        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-        return pico_ipv4_is_broadcast(hdr->dst.addr);
-    }
-#else
-    return 0;
-#endif
-}
-
-static int destination_is_mcast(struct pico_frame *f)
-{
-    int ret = 0;
-    if (!f)
-        return 0;
-
-#ifdef PICO_SUPPORT_IPV6
-    if (IS_IPV6(f)) {
-        struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *) f->net_hdr;
-        ret = pico_ipv6_is_multicast(hdr->dst.addr);
-    }
-
-#endif
-#ifdef PICO_SUPPORT_IPV4
-    else {
-        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-        ret = pico_ipv4_is_multicast(hdr->dst.addr);
-    }
-#endif
-
-    return ret;
-}
-
-#ifdef PICO_SUPPORT_IPV4
-static int32_t pico_ipv4_ethernet_receive(struct pico_frame *f)
-{
-    if (IS_IPV4(f)) {
-        pico_enqueue(pico_proto_ipv4.q_in, f);
-    } else {
-        (void)pico_icmp4_param_problem(f, 0);
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    return (int32_t)f->buffer_len;
-}
-#endif
-
-#ifdef PICO_SUPPORT_IPV6
-static int32_t pico_ipv6_ethernet_receive(struct pico_frame *f)
-{
-    if (IS_IPV6(f)) {
-        pico_enqueue(pico_proto_ipv6.q_in, f);
-    } else {
-        /* Wrong version for link layer type */
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    return (int32_t)f->buffer_len;
-}
-#endif
-
-static int32_t pico_ll_receive(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-
-#if (defined PICO_SUPPORT_IPV4) && (defined PICO_SUPPORT_ETH)
-    if (hdr->proto == PICO_IDETH_ARP)
-        return pico_arp_receive(f);
-
-#endif
-
-#if defined (PICO_SUPPORT_IPV4)
-    if (hdr->proto == PICO_IDETH_IPV4)
-        return pico_ipv4_ethernet_receive(f);
-
-#endif
-
-#if defined (PICO_SUPPORT_IPV6)
-    if (hdr->proto == PICO_IDETH_IPV6)
-        return pico_ipv6_ethernet_receive(f);
-
-#endif
-
-    pico_frame_discard(f);
-    return -1;
-}
-
-static void pico_ll_check_bcast(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    /* Indicate a link layer broadcast packet */
-    if (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) == 0)
-        f->flags |= PICO_FRAME_FLAG_BCAST;
-}
-
-int32_t pico_ethernet_receive(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr;
-    if (!f || !f->dev || !f->datalink_hdr)
-    {
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    if ((memcmp(hdr->daddr, f->dev->eth->mac.addr, PICO_SIZE_ETH) != 0) &&
-        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST, PICO_SIZE_MCAST) != 0) &&
-#ifdef PICO_SUPPORT_IPV6
-        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST6, PICO_SIZE_MCAST6) != 0) &&
-#endif
-        (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) != 0))
-    {
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    pico_ll_check_bcast(f);
-    return pico_ll_receive(f);
-}
-
-static struct pico_eth *pico_ethernet_mcast_translate(struct pico_frame *f, uint8_t *pico_mcast_mac)
-{
-    struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-
-    /* place 23 lower bits of IP in lower 23 bits of MAC */
-    pico_mcast_mac[5] = (long_be(hdr->dst.addr) & 0x000000FFu);
-    pico_mcast_mac[4] = (uint8_t)((long_be(hdr->dst.addr) & 0x0000FF00u) >> 8u);
-    pico_mcast_mac[3] = (uint8_t)((long_be(hdr->dst.addr) & 0x007F0000u) >> 16u);
-
-    return (struct pico_eth *)pico_mcast_mac;
-}
-
-
-#ifdef PICO_SUPPORT_IPV6
-static struct pico_eth *pico_ethernet_mcast6_translate(struct pico_frame *f, uint8_t *pico_mcast6_mac)
-{
-    struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *)f->net_hdr;
-
-    /* first 2 octets are 0x33, last four are the last four of dst */
-    pico_mcast6_mac[5] = hdr->dst.addr[PICO_SIZE_IP6 - 1];
-    pico_mcast6_mac[4] = hdr->dst.addr[PICO_SIZE_IP6 - 2];
-    pico_mcast6_mac[3] = hdr->dst.addr[PICO_SIZE_IP6 - 3];
-    pico_mcast6_mac[2] = hdr->dst.addr[PICO_SIZE_IP6 - 4];
-
-    return (struct pico_eth *)pico_mcast6_mac;
-}
-#endif
-
-static int pico_ethernet_ipv6_dst(struct pico_frame *f, struct pico_eth *const dstmac)
-{
-    int retval = -1;
-    if (!dstmac)
-        return -1;
-
-    #ifdef PICO_SUPPORT_IPV6
-    if (destination_is_mcast(f)) {
-        uint8_t pico_mcast6_mac[6] = {
-            0x33, 0x33, 0x00, 0x00, 0x00, 0x00
-        };
-        pico_ethernet_mcast6_translate(f, pico_mcast6_mac);
-        memcpy(dstmac, pico_mcast6_mac, PICO_SIZE_ETH);
-        retval = 0;
-    } else {
-        struct pico_eth *neighbor = pico_ipv6_get_neighbor(f);
-        if (neighbor)
-        {
-            memcpy(dstmac, neighbor, PICO_SIZE_ETH);
-            retval = 0;
-        }
-    }
-
-    #else
-    (void)f;
-    pico_err = PICO_ERR_EPROTONOSUPPORT;
-    #endif
-    return retval;
-}
-
-
-/* Ethernet send, first attempt: try our own address.
- * Returns 0 if the packet is not for us.
- * Returns 1 if the packet is cloned to our own receive queue, so the caller can discard the original frame.
- * */
-static int32_t pico_ethsend_local(struct pico_frame *f, struct pico_eth_hdr *hdr)
-{
-    if (!hdr)
-        return 0;
-
-    /* Check own mac */
-    if(!memcmp(hdr->daddr, hdr->saddr, PICO_SIZE_ETH)) {
-        struct pico_frame *clone = pico_frame_copy(f);
-        dbg("sending out packet destined for our own mac\n");
-        (void)pico_ethernet_receive(clone);
-        return 1;
-    }
-
-    return 0;
-}
-
-/* Ethernet send, second attempt: try bcast.
- * Returns 0 if the packet is not bcast, so it will be handled somewhere else.
- * Returns 1 if the packet is handled by the pico_device_broadcast() function, so it can be discarded.
- * */
-static int32_t pico_ethsend_bcast(struct pico_frame *f)
-{
-    if (IS_LIMITED_BCAST(f)) {
-        (void)pico_device_broadcast(f); /* We can discard broadcast even if it's not sent. */
-        return 1;
-    }
-
-    return 0;
-}
-
-/* Ethernet send, third attempt: try unicast.
- * If the device driver is busy, we return 0, so the stack won't discard the frame.
- * In case of success, we can safely return 1.
- */
-static int32_t pico_ethsend_dispatch(struct pico_frame *f)
-{
-    int ret = f->dev->send(f->dev, f->start, (int) f->len);
-    if (ret <= 0)
-        return 0; /* Failure to deliver! */
-    else {
-        return 1; /* Frame is in flight by now. */
-    }
-}
-
-
-
-
-/* This function looks for the destination mac address
- * in order to send the frame being processed.
- */
-
-int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
-{
-    struct pico_eth dstmac;
-    uint8_t dstmac_valid = 0;
-    uint16_t proto = PICO_IDETH_IPV4;
-
-#ifdef PICO_SUPPORT_IPV6
-    /* Step 1: If the frame has an IPv6 packet,
-     * destination address is taken from the ND tables
-     */
-    if (IS_IPV6(f)) {
-        if (pico_ethernet_ipv6_dst(f, &dstmac) < 0)
-        {
-            pico_ipv6_nd_postpone(f);
-            return 0; /* I don't care if frame was actually postponed. If there is no room in the ND table, discard safely. */
-        }
-
-        dstmac_valid = 1;
-        proto = PICO_IDETH_IPV6;
-    }
-    else
-#endif
-
-    /* In case of broadcast (IPV4 only), dst mac is FF:FF:... */
-    if (IS_BCAST(f) || destination_is_bcast(f))
-    {
-        memcpy(&dstmac, PICO_ETHADDR_ALL, PICO_SIZE_ETH);
-        dstmac_valid = 1;
-    }
-
-    /* In case of multicast, dst mac is translated from the group address */
-    else if (destination_is_mcast(f)) {
-        uint8_t pico_mcast_mac[6] = {
-            0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
-        };
-        pico_ethernet_mcast_translate(f, pico_mcast_mac);
-        memcpy(&dstmac, pico_mcast_mac, PICO_SIZE_ETH);
-        dstmac_valid = 1;
-    }
-
-#if (defined PICO_SUPPORT_IPV4)
-    else {
-        struct pico_eth *arp_get;
-        arp_get = pico_arp_get(f);
-        if (arp_get) {
-            memcpy(&dstmac, arp_get, PICO_SIZE_ETH);
-            dstmac_valid = 1;
-        } else {
-            /* At this point, ARP will discard the frame in any case.
-             * It is safe to return without discarding.
-             */
-            pico_arp_postpone(f);
-            return 0;
-            /* Same case as for IPv6 ... */
-        }
-
-    }
-#endif
-
-    /* This sets destination and source address, then pushes the packet to the device. */
-    if (dstmac_valid) {
-        struct pico_eth_hdr *hdr;
-        hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-        if ((f->start > f->buffer) && ((f->start - f->buffer) >= PICO_SIZE_ETHHDR))
-        {
-            f->start -= PICO_SIZE_ETHHDR;
-            f->len += PICO_SIZE_ETHHDR;
-            f->datalink_hdr = f->start;
-            hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-            memcpy(hdr->saddr, f->dev->eth->mac.addr, PICO_SIZE_ETH);
-            memcpy(hdr->daddr, &dstmac, PICO_SIZE_ETH);
-            hdr->proto = proto;
-        }
-
-        if (pico_ethsend_local(f, hdr) || pico_ethsend_bcast(f) || pico_ethsend_dispatch(f)) {
-            /* one of the above functions has delivered the frame accordingly. (returned != 0)
-             * It is safe to directly return success.
-             * */
-            return 0;
-        }
-    }
-
-    /* Failure: do not dequeue the frame, keep it for later. */
-    return -1;
-}
-
-#endif /* PICO_SUPPORT_ETH */
-
 
 void pico_store_network_origin(void *src, struct pico_frame *f)
 {
@@ -724,6 +369,39 @@ int pico_frame_dst_is_unicast(struct pico_frame *f)
     else return 0;
 }
 
+//===----------------------------------------------------------------------===//
+//  DATALINK LAYER
+//===----------------------------------------------------------------------===//
+
+int pico_datalink_receive(struct pico_frame *f)
+{
+    if (f->dev->eth) {
+        return pico_ethernet_receive(f);
+    }
+
+    /* TODO: Based on the device-mode, choose apropriate link-layer protocol to
+     * send frames through (upwards). */
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+int pico_datalink_send(struct pico_frame *f)
+{
+    if (f->dev->eth) {
+        return pico_ethernet_send(f);
+    }
+
+    /* TODO: Based on the device-mode, choose apropriate link-layer protocol to
+     * send frames through (downwards). */
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+//===----------------------------------------------------------------------===//
+//  PHYSICAL LAYER
+//===----------------------------------------------------------------------===//
 
 /* LOWEST LEVEL: interface towards devices. */
 /* Device driver will call this function which returns immediately.

--- a/test/unit/unit_arp.c
+++ b/test/unit/unit_arp.c
@@ -1,3 +1,5 @@
+#include "pico_ethernet.c"
+
 static struct pico_frame *init_frame(struct pico_device *dev)
 {
     struct pico_frame *f = pico_frame_alloc(PICO_SIZE_ETHHDR + PICO_SIZE_ARPHDR);


### PR DESCRIPTION
_This pull-request is a PoC to seperate ethernet from the stack and proposes an abstraction of link-layer protocols. This would enhance refactoring of 6LoWPAN and make it easier to support other link-layer protocols in the future._

Wouldn't it be cleaner if the ethernet-layer is seperated from the stack (see ```pico_stack.c```) in a seperate module like for example ```pico_ethernet.c```? I assume ethernet was included in the stack because ethernet was up until recently the only link-layer protocol available. But now with other link-layer protocols like 6LoWPAN/IEEE802.15.4 (you can consider it a single link layer protocol) it would be nice to have sort of an abstraction for different link-layer protocols.

Apart from modularity which was already provided by ifdef's this also enhances readability and maintainabilty of the stack itself a bit. You can then clearly see the hierarchy and the seperation of the layers in the stack.

##### pico_sendto_dev (not changed in pull-request)
I do have my doubts about ```pico_sendto_dev()``` however. When the network-layer wants to send a frame to the device it calls ```pico_sendto_dev(f)```. But then the frame gets enqueued directly into the device-queue although it may have to pass through the datalink-layer. It may not pass the link-layer as well, like for example with PPP. But wouldn't it also be better if the network-layer calls ```pico_datalink_send()``` instead where the frame is enqueued in the apropriate link-layer protocol queue? Whether or not the frame has to pass through the datalink-layer could also be decided there and if not, ```pico_datalink_send()``` just calls ```pico_sendto_dev()``` in it's turn. Or would another protocol-queue be redundant since you can use the one of the device itself?

Best regards,
Jelle