### PR TITLE
Abstraction of link-layer protocols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,6 @@ units: mod core lib $(UNITS_OBJ) $(MOD_OBJ)
 	@$(CC) -o $(PREFIX)/test/modunit_dns_sd.elf $(CFLAGS) -I. test/unit/modunit_pico_dns_sd.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_dev_loop.elf $(CFLAGS) -I. test/unit/modunit_pico_dev_loop.c -lcheck -lm -pthread -lrt $(UNITS_OBJ)
 	@$(CC) -o $(PREFIX)/test/modunit_ipv6_nd.elf $(CFLAGS) -I. test/unit/modunit_pico_ipv6_nd.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_ethernet.elf $(CFLAGS) -I. test/unit/modunit_pico_ethernet.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_pico_stack.elf $(CFLAGS) -I. test/unit/modunit_pico_stack.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_tftp.elf $(CFLAGS) -I. test/unit/modunit_pico_tftp.c  -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_sntp_client.elf $(CFLAGS) -I. test/unit/modunit_pico_sntp_client.c -lcheck -lm -pthread -lrt $(UNITS_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ units: mod core lib $(UNITS_OBJ) $(MOD_OBJ)
 	@$(CC) -o $(PREFIX)/test/modunit_dns_sd.elf $(CFLAGS) -I. test/unit/modunit_pico_dns_sd.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_dev_loop.elf $(CFLAGS) -I. test/unit/modunit_pico_dev_loop.c -lcheck -lm -pthread -lrt $(UNITS_OBJ)
 	@$(CC) -o $(PREFIX)/test/modunit_ipv6_nd.elf $(CFLAGS) -I. test/unit/modunit_pico_ipv6_nd.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_ethernet.elf $(CFLAGS) -I. test/unit/modunit_pico_ethernet.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_pico_stack.elf $(CFLAGS) -I. test/unit/modunit_pico_stack.c -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_tftp.elf $(CFLAGS) -I. test/unit/modunit_pico_tftp.c  -lcheck -lm -pthread -lrt $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 	@$(CC) -o $(PREFIX)/test/modunit_sntp_client.elf $(CFLAGS) -I. test/unit/modunit_pico_sntp_client.c -lcheck -lm -pthread -lrt $(UNITS_OBJ)

--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -16,14 +16,42 @@
 
 /* ===== RECEIVING FUNCTIONS (from dev up to socket) ===== */
 
-/* TRANSPORT LEVEL */
-/* interface towards network */
+//===----------------------------------------------------------------------===//
+//  TRANSPORT LAYER
+//===----------------------------------------------------------------------===//
+
+/* From dev up to socket */
 int32_t pico_transport_receive(struct pico_frame *f, uint8_t proto);
 
-/* NETWORK LEVEL */
-/* interface towards ethernet */
+//===----------------------------------------------------------------------===//
+//  NETWORK LAYER
+//===----------------------------------------------------------------------===//
+
+/* From socket down to dev */
+int32_t pico_network_send(struct pico_frame *f);
+
+/* From dev up to socket */
 int32_t pico_network_receive(struct pico_frame *f);
 
+//===----------------------------------------------------------------------===//
+//  DATALINK LAYER
+//===----------------------------------------------------------------------===//
+
+/* From socket down to dev */
+int pico_datalink_send(struct pico_frame *f);
+
+/* From dev up to socket */
+int pico_datalink_receive(struct pico_frame *f);
+
+/* Enqueues the frame in the device-queue. However, before the frame is
+ * actually send to the device itself, it may be possible that the frame passes
+ * through the datalink-layer first.
+ */
+int32_t pico_sendto_dev(struct pico_frame *f);
+
+//===----------------------------------------------------------------------===//
+//  PHYSICAL LAYER
+//===----------------------------------------------------------------------===//
 
 /* LOWEST LEVEL: interface towards devices. */
 /* Device driver will call this function which returns immediately.
@@ -35,26 +63,6 @@ int32_t pico_stack_recv(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy_ext_buffer(struct pico_device *dev, uint8_t *buffer, uint32_t len);
 int32_t pico_stack_recv_zerocopy_ext_buffer_notify(struct pico_device *dev, uint8_t *buffer, uint32_t len, void (*notify_free)(uint8_t *buffer));
-
-/* ===== SENDING FUNCTIONS (from socket down to dev) ===== */
-
-int32_t pico_network_send(struct pico_frame *f);
-int32_t pico_sendto_dev(struct pico_frame *f);
-
-#ifdef PICO_SUPPORT_ETH
-int32_t pico_ethernet_send(struct pico_frame *f);
-
-/* The pico_ethernet_receive() function is used by
- * those devices supporting ETH in order to push packets up
- * into the stack.
- */
-/* DATALINK LEVEL */
-int32_t pico_ethernet_receive(struct pico_frame *f);
-#else
-/* When ETH is not supported by the stack... */
-#   define pico_ethernet_send(f)    (-1)
-#   define pico_ethernet_receive(f) (-1)
-#endif
 
 /* ----- Initialization ----- */
 int pico_stack_init(void);

--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -40,18 +40,14 @@ int pico_datalink_send(struct pico_frame *f);
 
 /* From dev up to socket */
 int pico_datalink_receive(struct pico_frame *f);
-
-/* Enqueues the frame in the device-queue. However, before the frame is
- * actually send to the device itself, it may be possible that the frame passes
- * through the datalink-layer first.
- */
-int32_t pico_sendto_dev(struct pico_frame *f);
-
 //===----------------------------------------------------------------------===//
 //  PHYSICAL LAYER
 //===----------------------------------------------------------------------===//
 
-/* LOWEST LEVEL: interface towards devices. */
+/* Enqueues the frame in the device-queue. From socket down to dev */
+int32_t pico_sendto_dev(struct pico_frame *f);
+
+/* LOWEST LEVEL: interface towards stack from devices */
 /* Device driver will call this function which returns immediately.
  * Incoming packet will be processed later on in the dev loop.
  * The zerocopy version will associate the current buffer to the newly created frame.

--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -1,4 +1,3 @@
-
 /*********************************************************************
    PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
    See LICENSE and COPYING for usage.

--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -1,3 +1,4 @@
+
 /*********************************************************************
    PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
    See LICENSE and COPYING for usage.
@@ -13,8 +14,6 @@
 
 #define PICO_ETH_MRU (1514u)
 #define PICO_IP_MRU (1500u)
-
-/* ===== RECEIVING FUNCTIONS (from dev up to socket) ===== */
 
 //===----------------------------------------------------------------------===//
 //  TRANSPORT LAYER

--- a/modules/pico_arp.c
+++ b/modules/pico_arp.c
@@ -7,13 +7,13 @@
    Authors: Daniele Lacamera
  *********************************************************************/
 
-
 #include "pico_config.h"
 #include "pico_arp.h"
 #include "pico_tree.h"
 #include "pico_ipv4.h"
 #include "pico_device.h"
 #include "pico_stack.h"
+#include "pico_ethernet.h"
 
 extern const uint8_t PICO_ETHADDR_ALL[6];
 #define PICO_ARP_TIMEOUT 600000llu

--- a/modules/pico_arp.c
+++ b/modules/pico_arp.c
@@ -223,7 +223,7 @@ void pico_arp_postpone(struct pico_frame *f)
     {
         if (!frames_queued[i]) {
             if (f->failure_count < 4)
-                frames_queued[i] = pico_frame_copy(f);
+                frames_queued[i] = f;
 
             return;
         }

--- a/modules/pico_arp.c
+++ b/modules/pico_arp.c
@@ -38,11 +38,9 @@ static void pico_arp_queued_trigger(void)
     {
         f = frames_queued[i];
         if (f) {
-            if (!pico_ethernet_send(f))
-            {
-                pico_frame_discard(f);
-                frames_queued[i] = NULL;
-            }
+            if (pico_datalink_send(f) <= 0)
+                pico_datalink_send(f);
+            frames_queued[i] = NULL;
         }
     }
 }

--- a/modules/pico_arp.c
+++ b/modules/pico_arp.c
@@ -39,7 +39,7 @@ static void pico_arp_queued_trigger(void)
         f = frames_queued[i];
         if (f) {
             if (pico_datalink_send(f) <= 0)
-                pico_datalink_send(f);
+                pico_frame_discard(f);
             frames_queued[i] = NULL;
         }
     }

--- a/modules/pico_ethernet.c
+++ b/modules/pico_ethernet.c
@@ -1,0 +1,377 @@
+/*********************************************************************
+   PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
+   See LICENSE and COPYING for usage.
+
+   .
+
+   Authors: Daniele Lacamera
+ *********************************************************************/
+
+#include "pico_config.h"
+#include "pico_stack.h"
+#include "pico_ipv4.h"
+#include "pico_ipv6.h"
+#include "pico_icmp4.h"
+#include "pico_icmp6.h"
+#include "pico_arp.h"
+#include "pico_ethernet.h"
+
+#define IS_LIMITED_BCAST(f) (((struct pico_ipv4_hdr *) f->net_hdr)->dst.addr == PICO_IP4_BCAST)
+
+const uint8_t PICO_ETHADDR_ALL[6] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+# define PICO_SIZE_MCAST 3
+static const uint8_t PICO_ETHADDR_MCAST[6] = {
+    0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
+};
+
+#ifdef PICO_SUPPORT_IPV6
+# define PICO_SIZE_MCAST6 2
+static const uint8_t PICO_ETHADDR_MCAST6[6] = {
+    0x33, 0x33, 0x00, 0x00, 0x00, 0x00
+};
+#endif
+
+#ifdef PICO_SUPPORT_ETH
+/* DATALINK LEVEL: interface from network to the device
+ * and vice versa.
+ */
+
+/* The pico_ethernet_receive() function is used by
+ * those devices supporting ETH in order to push packets up
+ * into the stack.
+ */
+
+static int destination_is_bcast(struct pico_frame *f)
+{
+    if (!f)
+        return 0;
+
+    if (IS_IPV6(f))
+        return 0;
+
+#ifdef PICO_SUPPORT_IPV4
+    else {
+        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+        return pico_ipv4_is_broadcast(hdr->dst.addr);
+    }
+#else
+    return 0;
+#endif
+}
+
+static int destination_is_mcast(struct pico_frame *f)
+{
+    int ret = 0;
+    if (!f)
+        return 0;
+
+#ifdef PICO_SUPPORT_IPV6
+    if (IS_IPV6(f)) {
+        struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *) f->net_hdr;
+        ret = pico_ipv6_is_multicast(hdr->dst.addr);
+    }
+
+#endif
+#ifdef PICO_SUPPORT_IPV4
+    else {
+        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+        ret = pico_ipv4_is_multicast(hdr->dst.addr);
+    }
+#endif
+
+    return ret;
+}
+
+#ifdef PICO_SUPPORT_IPV4
+static int32_t pico_ipv4_ethernet_receive(struct pico_frame *f)
+{
+    if (IS_IPV4(f)) {
+        pico_enqueue(pico_proto_ipv4.q_in, f);
+    } else {
+        (void)pico_icmp4_param_problem(f, 0);
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    return (int32_t)f->buffer_len;
+}
+#endif
+
+#ifdef PICO_SUPPORT_IPV6
+static int32_t pico_ipv6_ethernet_receive(struct pico_frame *f)
+{
+    if (IS_IPV6(f)) {
+        pico_enqueue(pico_proto_ipv6.q_in, f);
+    } else {
+        /* Wrong version for link layer type */
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    return (int32_t)f->buffer_len;
+}
+#endif
+
+static int32_t pico_eth_receive(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+
+#if (defined PICO_SUPPORT_IPV4) && (defined PICO_SUPPORT_ETH)
+    if (hdr->proto == PICO_IDETH_ARP)
+        return pico_arp_receive(f);
+#endif
+
+#if defined (PICO_SUPPORT_IPV4)
+    if (hdr->proto == PICO_IDETH_IPV4)
+        return pico_ipv4_ethernet_receive(f);
+#endif
+
+#if defined (PICO_SUPPORT_IPV6)
+    if (hdr->proto == PICO_IDETH_IPV6)
+        return pico_ipv6_ethernet_receive(f);
+#endif
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+static void pico_eth_check_bcast(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    /* Indicate a link layer broadcast packet */
+    if (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) == 0)
+        f->flags |= PICO_FRAME_FLAG_BCAST;
+}
+
+int32_t pico_ethernet_receive(struct pico_frame *f)
+{
+    struct pico_eth_hdr *hdr;
+    if (!f || !f->dev || !f->datalink_hdr)
+    {
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+    if ((memcmp(hdr->daddr, f->dev->eth->mac.addr, PICO_SIZE_ETH) != 0) &&
+        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST, PICO_SIZE_MCAST) != 0) &&
+#ifdef PICO_SUPPORT_IPV6
+        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST6, PICO_SIZE_MCAST6) != 0) &&
+#endif
+        (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) != 0))
+    {
+        pico_frame_discard(f);
+        return -1;
+    }
+
+    pico_eth_check_bcast(f);
+    return pico_eth_receive(f);
+}
+
+static struct pico_eth *pico_ethernet_mcast_translate(struct pico_frame *f, uint8_t *pico_mcast_mac)
+{
+    struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
+
+    /* place 23 lower bits of IP in lower 23 bits of MAC */
+    pico_mcast_mac[5] = (long_be(hdr->dst.addr) & 0x000000FFu);
+    pico_mcast_mac[4] = (uint8_t)((long_be(hdr->dst.addr) & 0x0000FF00u) >> 8u);
+    pico_mcast_mac[3] = (uint8_t)((long_be(hdr->dst.addr) & 0x007F0000u) >> 16u);
+
+    return (struct pico_eth *)pico_mcast_mac;
+}
+
+
+#ifdef PICO_SUPPORT_IPV6
+static struct pico_eth *pico_ethernet_mcast6_translate(struct pico_frame *f, uint8_t *pico_mcast6_mac)
+{
+    struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *)f->net_hdr;
+
+    /* first 2 octets are 0x33, last four are the last four of dst */
+    pico_mcast6_mac[5] = hdr->dst.addr[PICO_SIZE_IP6 - 1];
+    pico_mcast6_mac[4] = hdr->dst.addr[PICO_SIZE_IP6 - 2];
+    pico_mcast6_mac[3] = hdr->dst.addr[PICO_SIZE_IP6 - 3];
+    pico_mcast6_mac[2] = hdr->dst.addr[PICO_SIZE_IP6 - 4];
+
+    return (struct pico_eth *)pico_mcast6_mac;
+}
+#endif
+
+static int pico_ethernet_ipv6_dst(struct pico_frame *f, struct pico_eth *const dstmac)
+{
+    int retval = -1;
+    if (!dstmac)
+        return -1;
+
+    #ifdef PICO_SUPPORT_IPV6
+    if (destination_is_mcast(f)) {
+        uint8_t pico_mcast6_mac[6] = {
+            0x33, 0x33, 0x00, 0x00, 0x00, 0x00
+        };
+        pico_ethernet_mcast6_translate(f, pico_mcast6_mac);
+        memcpy(dstmac, pico_mcast6_mac, PICO_SIZE_ETH);
+        retval = 0;
+    } else {
+        struct pico_eth *neighbor = pico_ipv6_get_neighbor(f);
+        if (neighbor)
+        {
+            memcpy(dstmac, neighbor, PICO_SIZE_ETH);
+            retval = 0;
+        }
+    }
+
+    #else
+    (void)f;
+    pico_err = PICO_ERR_EPROTONOSUPPORT;
+    #endif
+    return retval;
+}
+
+
+/* Ethernet send, first attempt: try our own address.
+ * Returns 0 if the packet is not for us.
+ * Returns 1 if the packet is cloned to our own receive queue, so the caller can discard the original frame.
+ * */
+static int32_t pico_ethsend_local(struct pico_frame *f, struct pico_eth_hdr *hdr)
+{
+    if (!hdr)
+        return 0;
+
+    /* Check own mac */
+    if(!memcmp(hdr->daddr, hdr->saddr, PICO_SIZE_ETH)) {
+        struct pico_frame *clone = pico_frame_copy(f);
+        dbg("sending out packet destined for our own mac\n");
+        (void)pico_ethernet_receive(clone);
+        return 1;
+    }
+
+    return 0;
+}
+
+/* Ethernet send, second attempt: try bcast.
+ * Returns 0 if the packet is not bcast, so it will be handled somewhere else.
+ * Returns 1 if the packet is handled by the pico_device_broadcast() function, so it can be discarded.
+ * */
+static int32_t pico_ethsend_bcast(struct pico_frame *f)
+{
+    if (IS_LIMITED_BCAST(f)) {
+        (void)pico_device_broadcast(f); /* We can discard broadcast even if it's not sent. */
+        return 1;
+    }
+
+    return 0;
+}
+
+/* Ethernet send, third attempt: try unicast.
+ * If the device driver is busy, we return 0, so the stack won't discard the frame.
+ * In case of success, we can safely return 1.
+ */
+static int32_t pico_ethsend_dispatch(struct pico_frame *f)
+{
+    int ret = f->dev->send(f->dev, f->start, (int) f->len);
+    if (ret <= 0)
+        return 0; /* Failure to deliver! */
+    else {
+        return 1; /* Frame is in flight by now. */
+    }
+}
+
+
+
+
+/* This function looks for the destination mac address
+ * in order to send the frame being processed.
+ */
+
+int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
+{
+    struct pico_eth dstmac;
+    uint8_t dstmac_valid = 0;
+    uint16_t proto = PICO_IDETH_IPV4;
+
+#ifdef PICO_SUPPORT_IPV6
+    /* Step 1: If the frame has an IPv6 packet,
+     * destination address is taken from the ND tables
+     */
+    if (IS_IPV6(f)) {
+        if (pico_ethernet_ipv6_dst(f, &dstmac) < 0)
+        {
+            pico_ipv6_nd_postpone(f);
+            return 0; /* I don't care if frame was actually postponed. If there is no room in the ND table, discard safely. */
+        }
+
+        dstmac_valid = 1;
+        proto = PICO_IDETH_IPV6;
+    }
+    else
+#endif
+
+    /* In case of broadcast (IPV4 only), dst mac is FF:FF:... */
+    if (IS_BCAST(f) || destination_is_bcast(f))
+    {
+        memcpy(&dstmac, PICO_ETHADDR_ALL, PICO_SIZE_ETH);
+        dstmac_valid = 1;
+    }
+
+    /* In case of multicast, dst mac is translated from the group address */
+    else if (destination_is_mcast(f)) {
+        uint8_t pico_mcast_mac[6] = {
+            0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
+        };
+        pico_ethernet_mcast_translate(f, pico_mcast_mac);
+        memcpy(&dstmac, pico_mcast_mac, PICO_SIZE_ETH);
+        dstmac_valid = 1;
+    }
+
+#if (defined PICO_SUPPORT_IPV4)
+    else {
+        struct pico_eth *arp_get;
+        arp_get = pico_arp_get(f);
+        if (arp_get) {
+            memcpy(&dstmac, arp_get, PICO_SIZE_ETH);
+            dstmac_valid = 1;
+        } else {
+            /* At this point, ARP will discard the frame in any case.
+             * It is safe to return without discarding.
+             */
+            pico_arp_postpone(f);
+            return 0;
+            /* Same case as for IPv6 ... */
+        }
+
+    }
+#endif
+
+    /* This sets destination and source address, then pushes the packet to the device. */
+    if (dstmac_valid) {
+        struct pico_eth_hdr *hdr;
+        hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+        if ((f->start > f->buffer) && ((f->start - f->buffer) >= PICO_SIZE_ETHHDR))
+        {
+            f->start -= PICO_SIZE_ETHHDR;
+            f->len += PICO_SIZE_ETHHDR;
+            f->datalink_hdr = f->start;
+            hdr = (struct pico_eth_hdr *) f->datalink_hdr;
+            memcpy(hdr->saddr, f->dev->eth->mac.addr, PICO_SIZE_ETH);
+            memcpy(hdr->daddr, &dstmac, PICO_SIZE_ETH);
+            hdr->proto = proto;
+        }
+
+        if (pico_ethsend_local(f, hdr) || pico_ethsend_bcast(f) || pico_ethsend_dispatch(f)) {
+            /* one of the above functions has delivered the frame accordingly. (returned != 0)
+             * It is safe to directly return success.
+             * */
+            return 0;
+        }
+    }
+
+    /* Failure: do not dequeue the frame, keep it for later. */
+    return -1;
+}
+
+#endif /* PICO_SUPPORT_ETH */
+
+

--- a/modules/pico_ethernet.c
+++ b/modules/pico_ethernet.c
@@ -322,6 +322,8 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
     if (IS_IPV6(f)) {
         if (pico_ethernet_ipv6_dst(f, &dstmac) < 0)
         {
+            /* Enqueue copy of frame in IPv6 ND-module to retry later. Discard
+             * frame otherwise we have a duplicate */
             pico_ipv6_nd_postpone(f);
             pico_frame_discard(f);
             return 0;
@@ -358,9 +360,8 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
             memcpy(&dstmac, arp_get, PICO_SIZE_ETH);
             dstmac_valid = 1;
         } else {
-            /* At this point, ARP will discard the frame in any case.
-             * It is safe to return without discarding.
-             */
+            /* Enqueue copy of frame in ARP-module to retry later. Discard
+             * frame otherwise we have a duplicate */
             pico_arp_postpone(f);
             pico_frame_discard(f);
             return 0;

--- a/modules/pico_ethernet.c
+++ b/modules/pico_ethernet.c
@@ -325,7 +325,6 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
             /* Enqueue copy of frame in IPv6 ND-module to retry later. Discard
              * frame otherwise we have a duplicate */
             pico_ipv6_nd_postpone(f);
-            pico_frame_discard(f);
             return 0;
         }
 
@@ -363,7 +362,6 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
             /* Enqueue copy of frame in ARP-module to retry later. Discard
              * frame otherwise we have a duplicate */
             pico_arp_postpone(f);
-            pico_frame_discard(f);
             return 0;
         }
 

--- a/modules/pico_ethernet.c
+++ b/modules/pico_ethernet.c
@@ -302,7 +302,7 @@ static int32_t pico_ethsend_bcast(struct pico_frame *f)
  */
 static int32_t pico_ethsend_dispatch(struct pico_frame *f)
 {
-    return pico_sendto_dev(f);
+    return (pico_sendto_dev(f) > 0); // Return 1 on success, ret > 0
 }
 
 /* This function looks for the destination mac address
@@ -324,7 +324,7 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
         {
             pico_ipv6_nd_postpone(f);
             pico_frame_discard(f);
-            return 0; /* I don't care if frame was actually postponed. If there is no room in the ND table, discard safely. */
+            return 0;
         }
 
         dstmac_valid = 1;
@@ -364,7 +364,6 @@ int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
             pico_arp_postpone(f);
             pico_frame_discard(f);
             return 0;
-            /* Same case as for IPv6 ... */
         }
 
     }

--- a/modules/pico_ethernet.h
+++ b/modules/pico_ethernet.h
@@ -1,0 +1,32 @@
+/*********************************************************************
+   PicoTCP. Copyright (c) 2012-2015 Altran Intelligent Systems. Some rights reserved.
+   See LICENSE and COPYING for usage.
+
+   .
+
+   Authors: Daniele Lacamera
+ *********************************************************************/
+
+#ifndef INCLUDE_PICO_ETHERNET
+#define INCLUDE_PICO_ETHERNET
+
+#include "pico_config.h"
+#include "pico_frame.h"
+
+#ifdef PICO_SUPPORT_ETH
+int32_t pico_ethernet_send(struct pico_frame *f);
+
+/* The pico_ethernet_receive() function is used by
+ * those devices supporting ETH in order to push packets up
+ * into the stack.
+ */
+/* DATALINK LEVEL */
+int32_t pico_ethernet_receive(struct pico_frame *f);
+
+#else
+/* When ETH is not supported by the stack... */
+#   define pico_ethernet_send(f)    (-1)
+#   define pico_ethernet_receive(f) (-1)
+#endif
+
+#endif /* INCLUDE_PICO_ETHERNET */

--- a/modules/pico_ethernet.h
+++ b/modules/pico_ethernet.h
@@ -14,6 +14,9 @@
 #include "pico_frame.h"
 
 #ifdef PICO_SUPPORT_ETH
+
+extern struct pico_protocol pico_proto_ethernet;
+
 int32_t pico_ethernet_send(struct pico_frame *f);
 
 /* The pico_ethernet_receive() function is used by

--- a/modules/pico_ipv4.c
+++ b/modules/pico_ipv4.c
@@ -476,7 +476,7 @@ static int pico_ipv4_process_out(struct pico_protocol *self, struct pico_frame *
     }
 
 #endif
-    return pico_sendto_dev(f);
+    return pico_datalink_send(f);
 }
 
 
@@ -1568,7 +1568,7 @@ static int pico_ipv4_forward(struct pico_frame *f)
     if (pico_ipv4_forward_check_dev(f) < 0)
         return -1;
 
-    pico_sendto_dev(f);
+    pico_datalink_send(f);
     return 0;
 
 }

--- a/modules/pico_ipv6.c
+++ b/modules/pico_ipv6.c
@@ -506,7 +506,7 @@ static int pico_ipv6_forward(struct pico_frame *f)
 
     f->start = f->net_hdr;
 
-    return pico_sendto_dev(f);
+    return pico_datalink_send(f);
 }
 
 
@@ -869,7 +869,8 @@ static int pico_ipv6_process_out(struct pico_protocol *self, struct pico_frame *
     IGNORE_PARAMETER(self);
 
     f->start = (uint8_t*)f->net_hdr;
-    return pico_sendto_dev(f);
+
+    return pico_datalink_send(f);
 }
 
 /* allocates an IPv6 packet without extension headers. If extension headers are needed,

--- a/modules/pico_ipv6_nd.c
+++ b/modules/pico_ipv6_nd.c
@@ -7,6 +7,7 @@
    Authors: Daniele Lacamera
  *********************************************************************/
 
+#include "pico_ethernet.h"
 #include "pico_config.h"
 #include "pico_tree.h"
 #include "pico_icmp6.h"

--- a/modules/pico_ipv6_nd.c
+++ b/modules/pico_ipv6_nd.c
@@ -951,11 +951,10 @@ void pico_ipv6_nd_postpone(struct pico_frame *f)
 {
     int i;
     static int last_enq = -1;
-    struct pico_frame *cp = pico_frame_copy(f);
     for (i = 0; i < PICO_ND_MAX_FRAMES_QUEUED; i++)
     {
         if (!frames_queued_v6[i]) {
-            frames_queued_v6[i] = cp;
+            frames_queued_v6[i] = f;
             last_enq = i;
             return;
         }
@@ -968,7 +967,7 @@ void pico_ipv6_nd_postpone(struct pico_frame *f)
     if (frames_queued_v6[last_enq])
         pico_frame_discard(frames_queued_v6[last_enq]);
 
-    frames_queued_v6[last_enq] = cp;
+    frames_queued_v6[last_enq] = f;
 }
 
 

--- a/modules/pico_ipv6_nd.c
+++ b/modules/pico_ipv6_nd.c
@@ -7,7 +7,6 @@
    Authors: Daniele Lacamera
  *********************************************************************/
 
-#include "pico_ethernet.h"
 #include "pico_config.h"
 #include "pico_tree.h"
 #include "pico_icmp6.h"
@@ -17,6 +16,7 @@
 #include "pico_eth.h"
 #include "pico_addressing.h"
 #include "pico_ipv6_nd.h"
+#include "pico_ethernet.h"
 
 #ifdef PICO_SUPPORT_IPV6
 
@@ -73,10 +73,8 @@ static void pico_ipv6_nd_queued_trigger(void)
     {
         f = frames_queued_v6[i];
         if (f) {
-            (void)pico_ethernet_send(f);
-            if(frames_queued_v6[i])
-                pico_frame_discard(frames_queued_v6[i]);
-
+            if (pico_datalink_send(f) <= 0)
+                pico_frame_discard(f);
             frames_queued_v6[i] = NULL;
         }
     }

--- a/rules/eth.mk
+++ b/rules/eth.mk
@@ -1,2 +1,3 @@
 OPTIONS+=-DPICO_SUPPORT_ETH
 MOD_OBJ+=$(LIBBASE)modules/pico_arp.o
+MOD_OBJ+=$(LIBBASE)modules/pico_ethernet.o

--- a/stack/pico_device.c
+++ b/stack/pico_device.c
@@ -16,6 +16,7 @@
 #include "pico_ipv4.h"
 #include "pico_icmp6.h"
 #include "pico_eth.h"
+
 #define PICO_DEVICE_DEFAULT_MTU (1500)
 
 struct pico_devices_rr_info {
@@ -243,7 +244,7 @@ static int devloop_in(struct pico_device *dev, int loop_score)
         if (f) {
             if (dev->eth) {
                 f->datalink_hdr = f->buffer;
-                (void)pico_ethernet_receive(f);
+                (void)pico_datalink_receive(f);
             } else {
                 f->net_hdr = f->buffer;
                 pico_network_receive(f);
@@ -259,8 +260,8 @@ static int devloop_sendto_dev(struct pico_device *dev, struct pico_frame *f)
 {
 
     if (dev->eth) {
-        /* Ethernet: pass management of the frame to the pico_ethernet_send() rdv function */
-        return pico_ethernet_send(f);
+        /* Datalink: pass management of the frame to the pico_datalink_send() rdv function */
+        return pico_datalink_send(f);
     } else {
         /* non-ethernet: no post-processing needed */
         return (dev->send(dev, f->start, (int)f->len) <= 0); /* Return 0 upon success, which is dev->send() > 0 */

--- a/stack/pico_device.c
+++ b/stack/pico_device.c
@@ -33,6 +33,7 @@ static int pico_dev_cmp(void *ka, void *kb)
     if (a->hash < b->hash)
         return -1;
 
+
     if (a->hash > b->hash)
         return 1;
 
@@ -242,14 +243,7 @@ static int devloop_in(struct pico_device *dev, int loop_score)
         /* Receive */
         f = pico_dequeue(dev->q_in);
         if (f) {
-            if (dev->eth) {
-                f->datalink_hdr = f->buffer;
-                (void)pico_datalink_receive(f);
-            } else {
-                f->net_hdr = f->buffer;
-                pico_network_receive(f);
-            }
-
+            pico_datalink_receive(f);
             loop_score--;
         }
     }
@@ -258,14 +252,7 @@ static int devloop_in(struct pico_device *dev, int loop_score)
 
 static int devloop_sendto_dev(struct pico_device *dev, struct pico_frame *f)
 {
-
-    if (dev->eth) {
-        /* Datalink: pass management of the frame to the pico_datalink_send() rdv function */
-        return pico_datalink_send(f);
-    } else {
-        /* non-ethernet: no post-processing needed */
-        return (dev->send(dev, f->start, (int)f->len) <= 0); /* Return 0 upon success, which is dev->send() > 0 */
-    }
+    return (dev->send(dev, f->start, (int)f->len) <= 0);
 }
 
 static int devloop_out(struct pico_device *dev, int loop_score)

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -16,6 +16,7 @@
 #include "pico_addressing.h"
 #include "pico_dns_client.h"
 
+#include "pico_ethernet.h"
 #include "pico_olsr.h"
 #include "pico_aodv.h"
 #include "pico_eth.h"
@@ -29,24 +30,6 @@
 #include "pico_tcp.h"
 #include "pico_socket.h"
 #include "heap.h"
-
-#define IS_LIMITED_BCAST(f) (((struct pico_ipv4_hdr *) f->net_hdr)->dst.addr == PICO_IP4_BCAST)
-
-const uint8_t PICO_ETHADDR_ALL[6] = {
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff
-};
-
-# define PICO_SIZE_MCAST 3
-static const uint8_t PICO_ETHADDR_MCAST[6] = {
-    0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
-};
-
-#ifdef PICO_SUPPORT_IPV6
-# define PICO_SIZE_MCAST6 2
-static const uint8_t PICO_ETHADDR_MCAST6[6] = {
-    0x33, 0x33, 0x00, 0x00, 0x00, 0x00
-};
-#endif
 
 /* Mockables */
 #if defined UNIT_TEST
@@ -197,8 +180,10 @@ int pico_notify_pkt_too_big(struct pico_frame *f)
     return 0;
 }
 
+//===----------------------------------------------------------------------===//
+//  TRANSPORT LAYER
+//===----------------------------------------------------------------------===//
 
-/* Transport layer */
 MOCKABLE int32_t pico_transport_receive(struct pico_frame *f, uint8_t proto)
 {
     int32_t ret = -1;
@@ -267,7 +252,11 @@ int32_t pico_network_receive(struct pico_frame *f)
     return (int32_t)f->buffer_len;
 }
 
-/* Network layer: interface towards socket for frame sending */
+//===----------------------------------------------------------------------===//
+//  NETWORK LAYER
+//===----------------------------------------------------------------------===//
+
+/// Interface towards socket for frame sending
 int32_t pico_network_send(struct pico_frame *f)
 {
     if (!f || !f->sock || !f->sock->net) {
@@ -301,350 +290,6 @@ int pico_source_is_local(struct pico_frame *f)
 #endif
     return 0;
 }
-
-#ifdef PICO_SUPPORT_ETH
-/* DATALINK LEVEL: interface from network to the device
- * and vice versa.
- */
-
-/* The pico_ethernet_receive() function is used by
- * those devices supporting ETH in order to push packets up
- * into the stack.
- */
-
-static int destination_is_bcast(struct pico_frame *f)
-{
-    if (!f)
-        return 0;
-
-    if (IS_IPV6(f))
-        return 0;
-
-#ifdef PICO_SUPPORT_IPV4
-    else {
-        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-        return pico_ipv4_is_broadcast(hdr->dst.addr);
-    }
-#else
-    return 0;
-#endif
-}
-
-static int destination_is_mcast(struct pico_frame *f)
-{
-    int ret = 0;
-    if (!f)
-        return 0;
-
-#ifdef PICO_SUPPORT_IPV6
-    if (IS_IPV6(f)) {
-        struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *) f->net_hdr;
-        ret = pico_ipv6_is_multicast(hdr->dst.addr);
-    }
-
-#endif
-#ifdef PICO_SUPPORT_IPV4
-    else {
-        struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-        ret = pico_ipv4_is_multicast(hdr->dst.addr);
-    }
-#endif
-
-    return ret;
-}
-
-#ifdef PICO_SUPPORT_IPV4
-static int32_t pico_ipv4_ethernet_receive(struct pico_frame *f)
-{
-    if (IS_IPV4(f)) {
-        pico_enqueue(pico_proto_ipv4.q_in, f);
-    } else {
-        (void)pico_icmp4_param_problem(f, 0);
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    return (int32_t)f->buffer_len;
-}
-#endif
-
-#ifdef PICO_SUPPORT_IPV6
-static int32_t pico_ipv6_ethernet_receive(struct pico_frame *f)
-{
-    if (IS_IPV6(f)) {
-        pico_enqueue(pico_proto_ipv6.q_in, f);
-    } else {
-        /* Wrong version for link layer type */
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    return (int32_t)f->buffer_len;
-}
-#endif
-
-static int32_t pico_ll_receive(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-
-#if (defined PICO_SUPPORT_IPV4) && (defined PICO_SUPPORT_ETH)
-    if (hdr->proto == PICO_IDETH_ARP)
-        return pico_arp_receive(f);
-
-#endif
-
-#if defined (PICO_SUPPORT_IPV4)
-    if (hdr->proto == PICO_IDETH_IPV4)
-        return pico_ipv4_ethernet_receive(f);
-
-#endif
-
-#if defined (PICO_SUPPORT_IPV6)
-    if (hdr->proto == PICO_IDETH_IPV6)
-        return pico_ipv6_ethernet_receive(f);
-
-#endif
-
-    pico_frame_discard(f);
-    return -1;
-}
-
-static void pico_ll_check_bcast(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    /* Indicate a link layer broadcast packet */
-    if (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) == 0)
-        f->flags |= PICO_FRAME_FLAG_BCAST;
-}
-
-int32_t pico_ethernet_receive(struct pico_frame *f)
-{
-    struct pico_eth_hdr *hdr;
-    if (!f || !f->dev || !f->datalink_hdr)
-    {
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-    if ((memcmp(hdr->daddr, f->dev->eth->mac.addr, PICO_SIZE_ETH) != 0) &&
-        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST, PICO_SIZE_MCAST) != 0) &&
-#ifdef PICO_SUPPORT_IPV6
-        (memcmp(hdr->daddr, PICO_ETHADDR_MCAST6, PICO_SIZE_MCAST6) != 0) &&
-#endif
-        (memcmp(hdr->daddr, PICO_ETHADDR_ALL, PICO_SIZE_ETH) != 0))
-    {
-        pico_frame_discard(f);
-        return -1;
-    }
-
-    pico_ll_check_bcast(f);
-    return pico_ll_receive(f);
-}
-
-static struct pico_eth *pico_ethernet_mcast_translate(struct pico_frame *f, uint8_t *pico_mcast_mac)
-{
-    struct pico_ipv4_hdr *hdr = (struct pico_ipv4_hdr *) f->net_hdr;
-
-    /* place 23 lower bits of IP in lower 23 bits of MAC */
-    pico_mcast_mac[5] = (long_be(hdr->dst.addr) & 0x000000FFu);
-    pico_mcast_mac[4] = (uint8_t)((long_be(hdr->dst.addr) & 0x0000FF00u) >> 8u);
-    pico_mcast_mac[3] = (uint8_t)((long_be(hdr->dst.addr) & 0x007F0000u) >> 16u);
-
-    return (struct pico_eth *)pico_mcast_mac;
-}
-
-
-#ifdef PICO_SUPPORT_IPV6
-static struct pico_eth *pico_ethernet_mcast6_translate(struct pico_frame *f, uint8_t *pico_mcast6_mac)
-{
-    struct pico_ipv6_hdr *hdr = (struct pico_ipv6_hdr *)f->net_hdr;
-
-    /* first 2 octets are 0x33, last four are the last four of dst */
-    pico_mcast6_mac[5] = hdr->dst.addr[PICO_SIZE_IP6 - 1];
-    pico_mcast6_mac[4] = hdr->dst.addr[PICO_SIZE_IP6 - 2];
-    pico_mcast6_mac[3] = hdr->dst.addr[PICO_SIZE_IP6 - 3];
-    pico_mcast6_mac[2] = hdr->dst.addr[PICO_SIZE_IP6 - 4];
-
-    return (struct pico_eth *)pico_mcast6_mac;
-}
-#endif
-
-static int pico_ethernet_ipv6_dst(struct pico_frame *f, struct pico_eth *const dstmac)
-{
-    int retval = -1;
-    if (!dstmac)
-        return -1;
-
-    #ifdef PICO_SUPPORT_IPV6
-    if (destination_is_mcast(f)) {
-        uint8_t pico_mcast6_mac[6] = {
-            0x33, 0x33, 0x00, 0x00, 0x00, 0x00
-        };
-        pico_ethernet_mcast6_translate(f, pico_mcast6_mac);
-        memcpy(dstmac, pico_mcast6_mac, PICO_SIZE_ETH);
-        retval = 0;
-    } else {
-        struct pico_eth *neighbor = pico_ipv6_get_neighbor(f);
-        if (neighbor)
-        {
-            memcpy(dstmac, neighbor, PICO_SIZE_ETH);
-            retval = 0;
-        }
-    }
-
-    #else
-    (void)f;
-    pico_err = PICO_ERR_EPROTONOSUPPORT;
-    #endif
-    return retval;
-}
-
-
-/* Ethernet send, first attempt: try our own address.
- * Returns 0 if the packet is not for us.
- * Returns 1 if the packet is cloned to our own receive queue, so the caller can discard the original frame.
- * */
-static int32_t pico_ethsend_local(struct pico_frame *f, struct pico_eth_hdr *hdr)
-{
-    if (!hdr)
-        return 0;
-
-    /* Check own mac */
-    if(!memcmp(hdr->daddr, hdr->saddr, PICO_SIZE_ETH)) {
-        struct pico_frame *clone = pico_frame_copy(f);
-        dbg("sending out packet destined for our own mac\n");
-        (void)pico_ethernet_receive(clone);
-        return 1;
-    }
-
-    return 0;
-}
-
-/* Ethernet send, second attempt: try bcast.
- * Returns 0 if the packet is not bcast, so it will be handled somewhere else.
- * Returns 1 if the packet is handled by the pico_device_broadcast() function, so it can be discarded.
- * */
-static int32_t pico_ethsend_bcast(struct pico_frame *f)
-{
-    if (IS_LIMITED_BCAST(f)) {
-        (void)pico_device_broadcast(f); /* We can discard broadcast even if it's not sent. */
-        return 1;
-    }
-
-    return 0;
-}
-
-/* Ethernet send, third attempt: try unicast.
- * If the device driver is busy, we return 0, so the stack won't discard the frame.
- * In case of success, we can safely return 1.
- */
-static int32_t pico_ethsend_dispatch(struct pico_frame *f)
-{
-    int ret = f->dev->send(f->dev, f->start, (int) f->len);
-    if (ret <= 0)
-        return 0; /* Failure to deliver! */
-    else {
-        return 1; /* Frame is in flight by now. */
-    }
-}
-
-
-
-
-/* This function looks for the destination mac address
- * in order to send the frame being processed.
- */
-
-int32_t MOCKABLE pico_ethernet_send(struct pico_frame *f)
-{
-    struct pico_eth dstmac;
-    uint8_t dstmac_valid = 0;
-    uint16_t proto = PICO_IDETH_IPV4;
-
-#ifdef PICO_SUPPORT_IPV6
-    /* Step 1: If the frame has an IPv6 packet,
-     * destination address is taken from the ND tables
-     */
-    if (IS_IPV6(f)) {
-        if (pico_ethernet_ipv6_dst(f, &dstmac) < 0)
-        {
-            pico_ipv6_nd_postpone(f);
-            return 0; /* I don't care if frame was actually postponed. If there is no room in the ND table, discard safely. */
-        }
-
-        dstmac_valid = 1;
-        proto = PICO_IDETH_IPV6;
-    }
-    else
-#endif
-
-    /* In case of broadcast (IPV4 only), dst mac is FF:FF:... */
-    if (IS_BCAST(f) || destination_is_bcast(f))
-    {
-        memcpy(&dstmac, PICO_ETHADDR_ALL, PICO_SIZE_ETH);
-        dstmac_valid = 1;
-    }
-
-    /* In case of multicast, dst mac is translated from the group address */
-    else if (destination_is_mcast(f)) {
-        uint8_t pico_mcast_mac[6] = {
-            0x01, 0x00, 0x5e, 0x00, 0x00, 0x00
-        };
-        pico_ethernet_mcast_translate(f, pico_mcast_mac);
-        memcpy(&dstmac, pico_mcast_mac, PICO_SIZE_ETH);
-        dstmac_valid = 1;
-    }
-
-#if (defined PICO_SUPPORT_IPV4)
-    else {
-        struct pico_eth *arp_get;
-        arp_get = pico_arp_get(f);
-        if (arp_get) {
-            memcpy(&dstmac, arp_get, PICO_SIZE_ETH);
-            dstmac_valid = 1;
-        } else {
-            /* At this point, ARP will discard the frame in any case.
-             * It is safe to return without discarding.
-             */
-            pico_arp_postpone(f);
-            return 0;
-            /* Same case as for IPv6 ... */
-        }
-
-    }
-#endif
-
-    /* This sets destination and source address, then pushes the packet to the device. */
-    if (dstmac_valid) {
-        struct pico_eth_hdr *hdr;
-        hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-        if ((f->start > f->buffer) && ((f->start - f->buffer) >= PICO_SIZE_ETHHDR))
-        {
-            f->start -= PICO_SIZE_ETHHDR;
-            f->len += PICO_SIZE_ETHHDR;
-            f->datalink_hdr = f->start;
-            hdr = (struct pico_eth_hdr *) f->datalink_hdr;
-            memcpy(hdr->saddr, f->dev->eth->mac.addr, PICO_SIZE_ETH);
-            memcpy(hdr->daddr, &dstmac, PICO_SIZE_ETH);
-            hdr->proto = proto;
-        }
-
-        if (pico_ethsend_local(f, hdr) || pico_ethsend_bcast(f) || pico_ethsend_dispatch(f)) {
-            /* one of the above functions has delivered the frame accordingly. (returned != 0)
-             * It is safe to directly return success.
-             * */
-            return 0;
-        }
-    }
-
-    /* Failure: do not dequeue the frame, keep it for later. */
-    return -1;
-}
-
-#endif /* PICO_SUPPORT_ETH */
-
 
 void pico_store_network_origin(void *src, struct pico_frame *f)
 {
@@ -724,6 +369,39 @@ int pico_frame_dst_is_unicast(struct pico_frame *f)
     else return 0;
 }
 
+//===----------------------------------------------------------------------===//
+//  DATALINK LAYER
+//===----------------------------------------------------------------------===//
+
+int pico_datalink_receive(struct pico_frame *f)
+{
+    if (f->dev->eth) {
+        return pico_ethernet_receive(f);
+    }
+
+    /* TODO: Based on the device-mode, choose apropriate link-layer protocol to
+     * send frames through (upwards). */
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+int pico_datalink_send(struct pico_frame *f)
+{
+    if (f->dev->eth) {
+        return pico_ethernet_send(f);
+    }
+
+    /* TODO: Based on the device-mode, choose apropriate link-layer protocol to
+     * send frames through (downwards). */
+
+    pico_frame_discard(f);
+    return -1;
+}
+
+//===----------------------------------------------------------------------===//
+//  PHYSICAL LAYER
+//===----------------------------------------------------------------------===//
 
 /* LOWEST LEVEL: interface towards devices. */
 /* Device driver will call this function which returns immediately.

--- a/test/unit/modunit_pico_ethernet.c
+++ b/test/unit/modunit_pico_ethernet.c
@@ -1,0 +1,372 @@
+//#include "pico_config.h"
+#include "pico_stack.h"
+#include "pico_ipv4.h"
+#include "pico_ipv6.h"
+#include "pico_icmp4.h"
+#include "pico_icmp6.h"
+#include "pico_arp.h"
+#include "pico_ethernet.h"
+#include "modules/pico_ethernet.c"
+#include "check.h"
+
+
+#define STARTING()                                                             \
+            printf("*********************** STARTING %s ***\n", __func__);     \
+            fflush(stdout)
+#define TRYING(s, ...)                                                         \
+            printf("Trying %s: " s, __func__, ##__VA_ARGS__);                  \
+            fflush(stdout)
+#define CHECKING(i)                                                            \
+            printf("Checking the results of test %2d in %s...", (i)++,         \
+                   __func__);                                                  \
+            fflush(stdout)
+#define SUCCESS()                                                              \
+            printf(" SUCCES\n");                                               \
+            fflush(stdout)
+#define BREAKING(s, ...)                                                       \
+            printf("Breaking %s: " s, __func__, ##__VA_ARGS__);                \
+            fflush(stdout)
+#define ENDING(i)                                                              \
+            printf("*********************** ENDING %s *** N TESTS: %d\n",      \
+                   __func__, ((i)-1));                                         \
+            fflush(stdout)
+#define DBG(s, ...)                                                            \
+            printf(s, ##__VA_ARGS__);                                          \
+            fflush(stdout)
+
+START_TEST(tc_pico_ethernet_process_out)
+{
+    /* Nothing to test calls pico_ethernet_send() in it's turn */
+}
+END_TEST
+START_TEST(tc_pico_ethernet_process_in)
+{
+    /* Nothing to test, calls pico_ethernet_receive() in it's turn */
+}
+END_TEST
+START_TEST(tc_destination_is_bcast)
+{
+    /* test this: static int destination_is_bcast(struct pico_frame *f) */
+    struct pico_ip6 addr = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9 }};
+    struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr));
+    struct pico_ipv6_hdr *h = (struct pico_ipv6_hdr *)f->buffer;
+    struct pico_ipv4_hdr *h4 = NULL;
+
+    /* Test parameters */
+    int ret = 0, count = 0;
+
+    f->net_hdr = (uint8_t*) h;
+    f->buffer[0] = 0x60; /* Ipv6 */
+
+    STARTING();
+
+    TRYING("With wrong protocol -> IPv6\n");
+    memcpy(h->dst.addr, addr.addr, PICO_SIZE_IP6);
+    ret = destination_is_bcast(f);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since IPv6 frame\n");
+    SUCCESS();
+    pico_frame_discard(f);
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr));
+    h4 = (struct pico_ipv4_hdr *)f->buffer;
+    f->net_hdr = (uint8_t *)h4;
+    f->buffer[0] = 0x40; /* IPv4 */
+    TRYING("With right protocol -> IPv4\n");
+    ret = destination_is_bcast(f);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since not a mcast address\n");
+    SUCCESS();
+
+    BREAKING();
+    ret = destination_is_bcast(NULL);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since NULL-pointer\n");
+    SUCCESS();
+
+    ENDING(count);
+}
+END_TEST
+START_TEST(tc_destination_is_mcast)
+{
+    struct pico_ip6 addr = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9 }};
+    struct pico_ip6 mcast = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9 }};
+    struct pico_ip4 addr4 = {0};
+    struct pico_ip4 mcast4 = {0};
+    struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr));
+    struct pico_ipv6_hdr *h = (struct pico_ipv6_hdr *)f->buffer;
+    struct pico_ipv4_hdr *h4 = (struct pico_ipv4_hdr *)f->buffer;
+    /* Test parameters */
+    int ret = 0, count = 0;
+
+    f->net_hdr = (uint8_t*) h;
+    f->buffer[0] = 0x60; /* Ipv6 */
+
+    STARTING();
+
+    pico_string_to_ipv4("232.1.1.0", &(mcast4.addr)); /* 0 */
+    pico_string_to_ipv4("10.20.0.1", &(addr4.addr));
+
+    pico_string_to_ipv6("ff00:0:0:0:0:0:e801:100", (mcast.addr)); /* 0 */
+    pico_string_to_ipv6("fe80:0:0:0:0:0:a28:100", (addr.addr)); /* 0 */
+
+    TRYING("With IPv6 unicast addr\n");
+    memcpy(h->dst.addr, addr.addr, PICO_SIZE_IP6);
+    ret = destination_is_mcast(f);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since not an IPv6 multicast\n");
+    SUCCESS();
+
+    TRYING("With IPv6 multicast addr\n");
+    memcpy(h->dst.addr, mcast.addr, PICO_SIZE_IP6);
+    ret = destination_is_mcast(f);
+    CHECKING(count);
+    fail_unless(1 == ret, "Should've returned 1 since an IPv6 multicast\n");
+    SUCCESS();
+
+    pico_frame_discard(f);
+    f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr));
+    h4 = (struct pico_ipv4_hdr *)f->buffer;
+    f->net_hdr = (uint8_t *)h4;
+    f->buffer[0] = 0x40; /* IPv4 */
+
+    TRYING("With IPv4 unicast addr\n");
+    h4->dst = addr4;
+    ret = destination_is_bcast(f);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since not an IPv4 mcast address\n");
+    SUCCESS();
+
+    TRYING("With IPv4 multicast addr\n");
+    h4->dst = mcast4;
+    ret = destination_is_mcast(f);
+    CHECKING(count);
+    fail_unless(1 == ret, "Should've returned 1 since an IPv4 multicast\n");
+    SUCCESS();
+
+    BREAKING();
+    ret = destination_is_bcast(NULL);
+    CHECKING(count);
+    fail_unless(0 == ret, "Should've returned 0 since NULL-pointer\n");
+    SUCCESS();
+
+    ENDING(count);
+}
+END_TEST
+START_TEST(tc_pico_ipv4_ethernet_receive)
+{
+   /* test this: static int32_t pico_ipv4_ethernet_receive(struct pico_frame *f) */
+    struct pico_frame *f = NULL;
+    struct pico_ipv4_hdr *h4 = NULL;
+    int ret = 0, count = 0;
+
+    STARTING();
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr));
+    h4 = (struct pico_ipv4_hdr *)f->buffer;
+    f->net_hdr = (uint8_t *)h4;
+    f->buffer[0] = 0x40; /* IPv4 */
+
+    TRYING("With IPv4 frame\n");
+    ret = pico_ipv4_ethernet_receive(f);
+    CHECKING(count);
+    fail_unless(ret > 0, "Was correct frame should've returned size of frame\n");
+    SUCCESS();
+    CHECKING(count);
+    fail_unless(pico_proto_ipv4.q_in->size == f->buffer_len, "Frame not enqueued\n");
+    SUCCESS();
+
+    ENDING(count);
+}
+END_TEST
+START_TEST(tc_pico_ipv6_ethernet_receive)
+{
+   /* test this: static int32_t pico_ipv6_ethernet_receive(struct pico_frame *f) */
+    struct pico_frame *f = NULL;
+    struct pico_ipv6_hdr *h = NULL;
+
+    int ret = 0, count = 0;
+
+    STARTING();
+    f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr));
+    h = (struct pico_ipv6_hdr *)f->buffer;
+    f->net_hdr = (uint8_t*) h;
+    f->buffer[0] = 0x40; /* Ipv6 */
+
+    TRYING("With wrong network type\n");
+    ret = pico_ipv6_ethernet_receive(f);
+    CHECKING(count);
+    fail_unless(ret == -1, "Wrong type should've returned an error\n");
+    SUCCESS();
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr));
+    h = (struct pico_ipv6_hdr *)f->buffer;
+    f->net_hdr = (uint8_t*) h;
+    f->buffer[0] = 0x60;
+    TRYING("With correct network type\n");
+    ret = pico_ipv6_ethernet_receive(f);
+    CHECKING(count);
+    fail_unless(ret == f->buffer_len, "Was correct frame, should've returned success\n");
+    SUCCESS();
+    CHECKING(count);
+    fail_unless(pico_proto_ipv6.q_in->size == f->buffer_len, "Frame not enqueued\n");
+    SUCCESS();
+
+    ENDING(count);
+}
+END_TEST
+START_TEST(tc_pico_eth_receive)
+{
+    struct pico_frame *f = NULL;
+    struct pico_ipv6_hdr *h = NULL;
+    struct pico_ipv4_hdr *h4 = NULL;
+    struct pico_eth_hdr *eth = NULL;
+    int ret = 0, count = 0;
+
+    STARTING();
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr) + sizeof(struct pico_eth_hdr));
+    f->datalink_hdr = f->buffer;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+    h = (struct pico_ipv6_hdr *)f->net_hdr;
+    eth = (struct pico_eth_hdr *)f->datalink_hdr;
+    ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
+
+    /* ETHERNET PROTOCOL : IPV6 */
+    eth->proto = PICO_IDETH_IPV6;
+
+    TRYING("With wrong network type\n");
+    ret = pico_eth_receive(f);
+    CHECKING(count);
+    fail_unless(ret == -1, "Wrong type should've returned an error\n");
+    SUCCESS();
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr) + sizeof(struct pico_eth_hdr));
+    f->datalink_hdr = f->buffer;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+    h = (struct pico_ipv6_hdr *)f->net_hdr;
+    eth = (struct pico_eth_hdr *)f->datalink_hdr;
+    ((uint8_t *)(f->net_hdr))[0] = 0x60; /* Ipv6 */
+
+    /* ETHERNET PROTOCOL : IPV6 */
+    eth->proto = PICO_IDETH_IPV6;
+    TRYING("With correct network type\n");
+    ret = pico_eth_receive(f);
+    CHECKING(count);
+    fail_unless(ret == f->buffer_len, "Was correct frame, should've returned success\n");
+    SUCCESS();
+    CHECKING(count);
+    fail_unless(pico_proto_ipv6.q_in->size == f->buffer_len, "Frame not enqueued\n");
+    SUCCESS();
+
+    pico_frame_discard(f);
+
+    f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr) + sizeof(struct pico_eth_hdr));
+    f->datalink_hdr = f->buffer;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+    h4 = (struct pico_ipv4_hdr *)f->net_hdr;
+    eth = (struct pico_eth_hdr *)f->datalink_hdr;
+    ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
+
+    TRYING("With wrong frame type\n");
+    ret = pico_eth_receive(f);
+    CHECKING(count);
+    fail_unless(ret > 0, "Was correct frame should've returned size of frame\n");
+    SUCCESS();
+
+    eth->proto = PICO_IDETH_IPV6;
+
+    TRYING("With IPv4 frame\n");
+    ret = pico_eth_receive(f);
+    CHECKING(count);
+    fail_unless(ret > 0, "Was correct frame should've returned size of frame\n");
+    SUCCESS();
+    CHECKING(count);
+    fail_unless(pico_proto_ipv4.q_in->size == f->buffer_len, "Frame not enqueued\n");
+    SUCCESS();
+
+    ENDING(count);
+}
+END_TEST
+START_TEST(tc_pico_eth_check_bcast)
+{
+    /* TODO: Test this */
+}
+END_TEST
+START_TEST(tc_pico_ethernet_ipv6_dst)
+{
+    /* TODO: Test this */
+}
+END_TEST
+START_TEST(tc_pico_ethsend_local)
+{
+    /* Nothign much to test */
+}
+END_TEST
+START_TEST(tc_pico_ethsend_bcast)
+{
+    /* Nothing much to test */
+}
+END_TEST
+START_TEST(tc_pico_ethsend_dispatch)
+{
+    /* Nothing much to test */
+}
+END_TEST
+
+
+Suite *pico_suite(void)
+{
+    Suite *s = suite_create("PicoTCP");
+
+    TCase *TCase_pico_ethernet_process_out = tcase_create("Unit test for pico_ethernet_process_out");
+    TCase *TCase_pico_ethernet_process_in = tcase_create("Unit test for pico_ethernet_process_in");
+    TCase *TCase_destination_is_bcast = tcase_create("Unit test for destination_is_bcast");
+    TCase *TCase_destination_is_mcast = tcase_create("Unit test for destination_is_mcast");
+    TCase *TCase_pico_ipv4_ethernet_receive = tcase_create("Unit test for pico_ipv4_ethernet_receive");
+    TCase *TCase_pico_ipv6_ethernet_receive = tcase_create("Unit test for pico_ipv6_ethernet_receive");
+    TCase *TCase_pico_eth_receive = tcase_create("Unit test for pico_eth_receive");
+    TCase *TCase_pico_eth_check_bcast = tcase_create("Unit test for pico_eth_check_bcast");
+    TCase *TCase_pico_ethernet_ipv6_dst = tcase_create("Unit test for pico_ethernet_ipv6_dst");
+    TCase *TCase_pico_ethsend_local = tcase_create("Unit test for pico_ethsend_local");
+    TCase *TCase_pico_ethsend_bcast = tcase_create("Unit test for pico_ethsend_bcast");
+    TCase *TCase_pico_ethsend_dispatch = tcase_create("Unit test for pico_ethsend_dispatch");
+
+
+    tcase_add_test(TCase_pico_ethernet_process_out, tc_pico_ethernet_process_out);
+    suite_add_tcase(s, TCase_pico_ethernet_process_out);
+    tcase_add_test(TCase_pico_ethernet_process_in, tc_pico_ethernet_process_in);
+    suite_add_tcase(s, TCase_pico_ethernet_process_in);
+    tcase_add_test(TCase_destination_is_bcast, tc_destination_is_bcast);
+    suite_add_tcase(s, TCase_destination_is_bcast);
+    tcase_add_test(TCase_destination_is_mcast, tc_destination_is_mcast);
+    suite_add_tcase(s, TCase_destination_is_mcast);
+    tcase_add_test(TCase_pico_ipv4_ethernet_receive, tc_pico_ipv4_ethernet_receive);
+    suite_add_tcase(s, TCase_pico_ipv4_ethernet_receive);
+    tcase_add_test(TCase_pico_ipv6_ethernet_receive, tc_pico_ipv6_ethernet_receive);
+    suite_add_tcase(s, TCase_pico_ipv6_ethernet_receive);
+    tcase_add_test(TCase_pico_eth_receive, tc_pico_eth_receive);
+    suite_add_tcase(s, TCase_pico_eth_receive);
+    tcase_add_test(TCase_pico_eth_check_bcast, tc_pico_eth_check_bcast);
+    suite_add_tcase(s, TCase_pico_eth_check_bcast);
+    tcase_add_test(TCase_pico_ethernet_ipv6_dst, tc_pico_ethernet_ipv6_dst);
+    suite_add_tcase(s, TCase_pico_ethernet_ipv6_dst);
+    tcase_add_test(TCase_pico_ethsend_local, tc_pico_ethsend_local);
+    suite_add_tcase(s, TCase_pico_ethsend_local);
+    tcase_add_test(TCase_pico_ethsend_bcast, tc_pico_ethsend_bcast);
+    suite_add_tcase(s, TCase_pico_ethsend_bcast);
+    tcase_add_test(TCase_pico_ethsend_dispatch, tc_pico_ethsend_dispatch);
+    suite_add_tcase(s, TCase_pico_ethsend_dispatch);
+return s;
+}
+
+int main(void)
+{
+    int fails;
+    Suite *s = pico_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    fails = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return fails;
+}

--- a/test/unit/modunit_pico_ethernet.c
+++ b/test/unit/modunit_pico_ethernet.c
@@ -271,10 +271,16 @@ START_TEST(tc_pico_eth_receive)
     TRYING("With wrong frame type\n");
     ret = pico_eth_receive(f);
     CHECKING(count);
-    fail_unless(ret > 0, "Was correct frame should've returned size of frame\n");
+    fail_unless(ret == -1, "should've returned -1 wrong ethernet protocol\n");
     SUCCESS();
 
-    eth->proto = PICO_IDETH_IPV6;
+    f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr) + sizeof(struct pico_eth_hdr));
+    f->datalink_hdr = f->buffer;
+    f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
+    h4 = (struct pico_ipv4_hdr *)f->net_hdr;
+    eth = (struct pico_eth_hdr *)f->datalink_hdr;
+    ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
+    eth->proto = PICO_IDETH_IPV4;
 
     TRYING("With IPv4 frame\n");
     ret = pico_eth_receive(f);

--- a/test/unit/modunit_pico_ethernet.c
+++ b/test/unit/modunit_pico_ethernet.c
@@ -33,17 +33,6 @@
 #define DBG(s, ...)                                                            \
             printf(s, ##__VA_ARGS__);                                          \
             fflush(stdout)
-
-START_TEST(tc_pico_ethernet_process_out)
-{
-    /* Nothing to test calls pico_ethernet_send() in it's turn */
-}
-END_TEST
-START_TEST(tc_pico_ethernet_process_in)
-{
-    /* Nothing to test, calls pico_ethernet_receive() in it's turn */
-}
-END_TEST
 START_TEST(tc_destination_is_bcast)
 {
     /* test this: static int destination_is_bcast(struct pico_frame *f) */
@@ -294,55 +283,17 @@ START_TEST(tc_pico_eth_receive)
     ENDING(count);
 }
 END_TEST
-START_TEST(tc_pico_eth_check_bcast)
-{
-    /* TODO: Test this */
-}
-END_TEST
-START_TEST(tc_pico_ethernet_ipv6_dst)
-{
-    /* TODO: Test this */
-}
-END_TEST
-START_TEST(tc_pico_ethsend_local)
-{
-    /* Nothign much to test */
-}
-END_TEST
-START_TEST(tc_pico_ethsend_bcast)
-{
-    /* Nothing much to test */
-}
-END_TEST
-START_TEST(tc_pico_ethsend_dispatch)
-{
-    /* Nothing much to test */
-}
-END_TEST
-
 
 Suite *pico_suite(void)
 {
     Suite *s = suite_create("PicoTCP");
 
-    TCase *TCase_pico_ethernet_process_out = tcase_create("Unit test for pico_ethernet_process_out");
-    TCase *TCase_pico_ethernet_process_in = tcase_create("Unit test for pico_ethernet_process_in");
     TCase *TCase_destination_is_bcast = tcase_create("Unit test for destination_is_bcast");
     TCase *TCase_destination_is_mcast = tcase_create("Unit test for destination_is_mcast");
     TCase *TCase_pico_ipv4_ethernet_receive = tcase_create("Unit test for pico_ipv4_ethernet_receive");
     TCase *TCase_pico_ipv6_ethernet_receive = tcase_create("Unit test for pico_ipv6_ethernet_receive");
     TCase *TCase_pico_eth_receive = tcase_create("Unit test for pico_eth_receive");
-    TCase *TCase_pico_eth_check_bcast = tcase_create("Unit test for pico_eth_check_bcast");
-    TCase *TCase_pico_ethernet_ipv6_dst = tcase_create("Unit test for pico_ethernet_ipv6_dst");
-    TCase *TCase_pico_ethsend_local = tcase_create("Unit test for pico_ethsend_local");
-    TCase *TCase_pico_ethsend_bcast = tcase_create("Unit test for pico_ethsend_bcast");
-    TCase *TCase_pico_ethsend_dispatch = tcase_create("Unit test for pico_ethsend_dispatch");
 
-
-    tcase_add_test(TCase_pico_ethernet_process_out, tc_pico_ethernet_process_out);
-    suite_add_tcase(s, TCase_pico_ethernet_process_out);
-    tcase_add_test(TCase_pico_ethernet_process_in, tc_pico_ethernet_process_in);
-    suite_add_tcase(s, TCase_pico_ethernet_process_in);
     tcase_add_test(TCase_destination_is_bcast, tc_destination_is_bcast);
     suite_add_tcase(s, TCase_destination_is_bcast);
     tcase_add_test(TCase_destination_is_mcast, tc_destination_is_mcast);
@@ -353,17 +304,7 @@ Suite *pico_suite(void)
     suite_add_tcase(s, TCase_pico_ipv6_ethernet_receive);
     tcase_add_test(TCase_pico_eth_receive, tc_pico_eth_receive);
     suite_add_tcase(s, TCase_pico_eth_receive);
-    tcase_add_test(TCase_pico_eth_check_bcast, tc_pico_eth_check_bcast);
-    suite_add_tcase(s, TCase_pico_eth_check_bcast);
-    tcase_add_test(TCase_pico_ethernet_ipv6_dst, tc_pico_ethernet_ipv6_dst);
-    suite_add_tcase(s, TCase_pico_ethernet_ipv6_dst);
-    tcase_add_test(TCase_pico_ethsend_local, tc_pico_ethsend_local);
-    suite_add_tcase(s, TCase_pico_ethsend_local);
-    tcase_add_test(TCase_pico_ethsend_bcast, tc_pico_ethsend_bcast);
-    suite_add_tcase(s, TCase_pico_ethsend_bcast);
-    tcase_add_test(TCase_pico_ethsend_dispatch, tc_pico_ethsend_dispatch);
-    suite_add_tcase(s, TCase_pico_ethsend_dispatch);
-return s;
+    return s;
 }
 
 int main(void)

--- a/test/unit/modunit_pico_stack.c
+++ b/test/unit/modunit_pico_stack.c
@@ -77,8 +77,8 @@ void fake_timer(pico_time __attribute__((unused)) now, void __attribute__((unuse
 START_TEST(tc_stack_generic)
 {
 #ifdef PICO_FAULTY
-    printf("Testing with faulty memory in pico_stack_init (10)\n");
-    pico_set_mm_failure(10);
+    printf("Testing with faulty memory in pico_stack_init (11)\n");
+    pico_set_mm_failure(11);
     fail_if(pico_stack_init() != -1);
 #endif
     pico_stack_init();

--- a/test/unit/unit_arp.c
+++ b/test/unit/unit_arp.c
@@ -1,3 +1,5 @@
+#include "pico_ethernet.c"
+
 static struct pico_frame *init_frame(struct pico_device *dev)
 {
     struct pico_frame *f = pico_frame_alloc(PICO_SIZE_ETHHDR + PICO_SIZE_ARPHDR);

--- a/test/units.sh
+++ b/test/units.sh
@@ -4,6 +4,7 @@ rm -f /tmp/pico-mem-report-*
 ASAN_OPTIONS="detect_leaks=0" ./build/test/units || exit 1
 ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_fragments.elf || exit 1
 ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_pico_stack.elf || exit 1
+ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_ethernet.elf || exit 1
 ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_pico_protocol.elf || exit 1
 ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_pico_frame.elf || exit 1
 ASAN_OPTIONS="detect_leaks=0" ./build/test/modunit_seq.elf || exit 1


### PR DESCRIPTION
_This pull-request seperates ethernet from the stack, gives it it's own queues and ```pico_protocol```-definition and proposes an abstraction for link-layer protocols. This would enhance refactoring of 6LoWPAN and make it easier to support other link-layer protocols in the future._

@frederikvs, here's the full PoC as I intended with #375. As you can see, it squeezes another layer (```pico_protocol```) between the networking-layer and the physical layer.

Reasons to pull (:smile:) :
- Unit tests provided
- Autotest.sh works
- Units work too

Best regards,
Jelle