### PR TITLE
pico_stack.c: fix pico_timer_cancel

### DIFF
--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -902,6 +902,7 @@ void MOCKABLE pico_timer_cancel(uint32_t id)
         if (tref[i].id == id) {
             PICO_FREE(Timers->top[i].tmr);
             Timers->top[i].tmr = NULL;
+            heap_peek(Timers, &tref_unused);
             break;
         }
     }


### PR DESCRIPTION
When a timer is cancelled, it has to be removed from the tree.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
