### PR TITLE
[pico_protocol] - Added 'device'-param to pico_protocol's alloc-function 

### DIFF
--- a/include/pico_frame.h
+++ b/include/pico_frame.h
@@ -92,6 +92,7 @@ struct pico_frame *pico_frame_copy(struct pico_frame *f);
 struct pico_frame *pico_frame_deepcopy(struct pico_frame *f);
 struct pico_frame *pico_frame_alloc(uint32_t size);
 int pico_frame_grow(struct pico_frame *f, uint32_t size);
+int pico_frame_grow_head(struct pico_frame *f, uint32_t size);
 struct pico_frame *pico_frame_alloc_skeleton(uint32_t size, int ext_buffer);
 int pico_frame_skeleton_set_buffer(struct pico_frame *f, void *buf);
 uint16_t pico_checksum(void *inbuf, uint32_t len);

--- a/include/pico_protocol.h
+++ b/include/pico_protocol.h
@@ -77,7 +77,7 @@ struct pico_protocol {
     uint16_t proto_number;
     struct pico_queue *q_in;
     struct pico_queue *q_out;
-    struct pico_frame *(*alloc)(struct pico_protocol *self, uint16_t size); /* Frame allocation. */
+    struct pico_frame *(*alloc)(struct pico_protocol *self, struct pico_device *dev, uint16_t size); /* Frame allocation. */
     int (*push)(struct pico_protocol *self, struct pico_frame *p);    /* Push function, for active outgoing pkts from above */
     int (*process_out)(struct pico_protocol *self, struct pico_frame *p);  /* Send loop. */
     int (*process_in)(struct pico_protocol *self, struct pico_frame *p);  /* Recv loop. */

--- a/include/pico_socket.h
+++ b/include/pico_socket.h
@@ -208,7 +208,9 @@ int pico_socket_getoption(struct pico_socket *s, int option, void *value);
 int pico_socket_shutdown(struct pico_socket *s, int mode);
 int pico_socket_close(struct pico_socket *s);
 
-struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, uint16_t len);
+struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, struct pico_device *dev, uint16_t len);
+struct pico_device *get_sock_dev(struct pico_socket *s);
+
 
 #ifdef PICO_SUPPORT_IPV4
 # define is_sock_ipv4(x) (x->net == &pico_proto_ipv4)

--- a/modules/pico_icmp4.c
+++ b/modules/pico_icmp4.c
@@ -125,7 +125,7 @@ static int pico_icmp4_notify(struct pico_frame *f, uint8_t type, uint8_t code)
         f_tot_len = (sizeof(struct pico_ipv4_hdr) + 8u);
     }
 
-    reply = pico_proto_ipv4.alloc(&pico_proto_ipv4, NULL, (uint16_t) (f_tot_len + PICO_ICMPHDR_UN_SIZE));
+    reply = pico_proto_ipv4.alloc(&pico_proto_ipv4, f->dev, (uint16_t) (f_tot_len + PICO_ICMPHDR_UN_SIZE));
     info = (struct pico_ipv4_hdr*)(f->net_hdr);
     hdr = (struct pico_icmp4_hdr *) reply->transport_hdr;
     hdr->type = type;
@@ -229,11 +229,15 @@ static PICO_TREE_DECLARE(Pings, cookie_compare);
 
 static int8_t pico_icmp4_send_echo(struct pico_icmp4_ping_cookie *cookie)
 {
-    struct pico_frame *echo = pico_proto_ipv4.alloc(&pico_proto_ipv4, NULL, (uint16_t)(PICO_ICMPHDR_UN_SIZE + cookie->size));
+    struct pico_frame *echo = NULL;
     struct pico_icmp4_hdr *hdr;
-    if (!echo) {
+    struct pico_device *dev = pico_ipv4_source_dev_find(&cookie->dst);
+    if (!dev)
         return -1;
-    }
+
+    echo = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, (uint16_t)(PICO_ICMPHDR_UN_SIZE + cookie->size));
+    if (!echo)
+        return -1;
 
     hdr = (struct pico_icmp4_hdr *) echo->transport_hdr;
 

--- a/modules/pico_icmp4.c
+++ b/modules/pico_icmp4.c
@@ -125,7 +125,7 @@ static int pico_icmp4_notify(struct pico_frame *f, uint8_t type, uint8_t code)
         f_tot_len = (sizeof(struct pico_ipv4_hdr) + 8u);
     }
 
-    reply = pico_proto_ipv4.alloc(&pico_proto_ipv4, (uint16_t) (f_tot_len + PICO_ICMPHDR_UN_SIZE));
+    reply = pico_proto_ipv4.alloc(&pico_proto_ipv4, NULL, (uint16_t) (f_tot_len + PICO_ICMPHDR_UN_SIZE));
     info = (struct pico_ipv4_hdr*)(f->net_hdr);
     hdr = (struct pico_icmp4_hdr *) reply->transport_hdr;
     hdr->type = type;
@@ -229,7 +229,7 @@ static PICO_TREE_DECLARE(Pings, cookie_compare);
 
 static int8_t pico_icmp4_send_echo(struct pico_icmp4_ping_cookie *cookie)
 {
-    struct pico_frame *echo = pico_proto_ipv4.alloc(&pico_proto_ipv4, (uint16_t)(PICO_ICMPHDR_UN_SIZE + cookie->size));
+    struct pico_frame *echo = pico_proto_ipv4.alloc(&pico_proto_ipv4, NULL, (uint16_t)(PICO_ICMPHDR_UN_SIZE + cookie->size));
     struct pico_icmp4_hdr *hdr;
     if (!echo) {
         return -1;

--- a/modules/pico_icmp6.c
+++ b/modules/pico_icmp6.c
@@ -51,7 +51,7 @@ static int pico_icmp6_send_echoreply(struct pico_frame *echo)
     struct pico_ip6 src;
     struct pico_ip6 dst;
 
-    reply = pico_proto_ipv6.alloc(&pico_proto_ipv6, (uint16_t)(echo->transport_len));
+    reply = pico_proto_ipv6.alloc(&pico_proto_ipv6, echo->dev, (uint16_t)(echo->transport_len));
     if (!reply) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -60,7 +60,6 @@ static int pico_icmp6_send_echoreply(struct pico_frame *echo)
     echo->payload = echo->transport_hdr + PICO_ICMP6HDR_ECHO_REQUEST_SIZE;
     reply->payload = reply->transport_hdr + PICO_ICMP6HDR_ECHO_REQUEST_SIZE;
     reply->payload_len = echo->transport_len;
-    reply->dev = echo->dev;
 
     ehdr = (struct pico_icmp6_hdr *)echo->transport_hdr;
     rhdr = (struct pico_icmp6_hdr *)reply->transport_hdr;
@@ -156,7 +155,7 @@ static int pico_icmp6_notify(struct pico_frame *f, uint8_t type, uint8_t code, u
         if (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_DEST_UNREACH_SIZE + len > PICO_IPV6_MIN_MTU)
             len = PICO_IPV6_MIN_MTU - (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_DEST_UNREACH_SIZE);
 
-        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, (uint16_t)(PICO_ICMP6HDR_DEST_UNREACH_SIZE + len));
+        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, f->dev, (uint16_t)(PICO_ICMP6HDR_DEST_UNREACH_SIZE + len));
         if (!notice) {
             pico_err = PICO_ERR_ENOMEM;
             return -1;
@@ -173,7 +172,7 @@ static int pico_icmp6_notify(struct pico_frame *f, uint8_t type, uint8_t code, u
         if (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_TIME_XCEEDED_SIZE + len > PICO_IPV6_MIN_MTU)
             len = PICO_IPV6_MIN_MTU - (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_TIME_XCEEDED_SIZE);
 
-        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, (uint16_t)(PICO_ICMP6HDR_TIME_XCEEDED_SIZE + len));
+        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, f->dev, (uint16_t)(PICO_ICMP6HDR_TIME_XCEEDED_SIZE + len));
         if (!notice) {
             pico_err = PICO_ERR_ENOMEM;
             return -1;
@@ -189,7 +188,7 @@ static int pico_icmp6_notify(struct pico_frame *f, uint8_t type, uint8_t code, u
         if (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_PARAM_PROBLEM_SIZE + len > PICO_IPV6_MIN_MTU)
             len = PICO_IPV6_MIN_MTU - (PICO_SIZE_IP6HDR + PICO_ICMP6HDR_PARAM_PROBLEM_SIZE);
 
-        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, (uint16_t)(PICO_ICMP6HDR_PARAM_PROBLEM_SIZE + len));
+        notice = pico_proto_ipv6.alloc(&pico_proto_ipv6, f->dev, (uint16_t)(PICO_ICMP6HDR_PARAM_PROBLEM_SIZE + len));
         if (!notice) {
             pico_err = PICO_ERR_ENOMEM;
             return -1;
@@ -208,7 +207,6 @@ static int pico_icmp6_notify(struct pico_frame *f, uint8_t type, uint8_t code, u
     icmp6_hdr->type = type;
     icmp6_hdr->code = code;
     memcpy(notice->payload, f->net_hdr, notice->payload_len);
-    notice->dev = f->dev;
     /* f->src is set in frame_push, checksum calculated there */
     pico_ipv6_frame_push(notice, NULL, &ipv6_hdr->src, PICO_PROTO_ICMP6, 0);
     return 0;
@@ -297,7 +295,7 @@ int pico_icmp6_neighbor_solicitation(struct pico_device *dev, struct pico_ip6 *d
     if (type != PICO_ICMP6_ND_DAD)
         len = (uint16_t)(len + 8);
 
-    sol = pico_proto_ipv6.alloc(&pico_proto_ipv6, len);
+    sol = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, len);
     if (!sol) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -327,8 +325,6 @@ int pico_icmp6_neighbor_solicitation(struct pico_device *dev, struct pico_ip6 *d
         daddr = *dst;
     }
 
-    sol->dev = dev;
-
     /* f->src is set in frame_push, checksum calculated there */
     pico_ipv6_frame_push(sol, NULL, &daddr, PICO_PROTO_ICMP6, (type == PICO_ICMP6_ND_DAD));
     return 0;
@@ -344,7 +340,7 @@ int pico_icmp6_neighbor_advertisement(struct pico_frame *f, struct pico_ip6 *tar
     struct pico_ip6 dst = {{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
 
     ipv6_hdr = (struct pico_ipv6_hdr *)f->net_hdr;
-    adv = pico_proto_ipv6.alloc(&pico_proto_ipv6, PICO_ICMP6HDR_NEIGH_ADV_SIZE + 8);
+    adv = pico_proto_ipv6.alloc(&pico_proto_ipv6, f->dev, PICO_ICMP6HDR_NEIGH_ADV_SIZE + 8);
     if (!adv) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -380,7 +376,6 @@ int pico_icmp6_neighbor_advertisement(struct pico_frame *f, struct pico_ip6 *tar
     opt->type = PICO_ND_OPT_LLADDR_TGT;
     opt->len = 1;
     memcpy(opt->addr.mac.addr, f->dev->eth->mac.addr, PICO_SIZE_ETH);
-    adv->dev = f->dev;
 
     /* f->src is set in frame_push, checksum calculated there */
     pico_ipv6_frame_push(adv, NULL, &dst, PICO_PROTO_ICMP6, 0);
@@ -400,7 +395,7 @@ int pico_icmp6_router_solicitation(struct pico_device *dev, struct pico_ip6 *src
     if (!pico_ipv6_is_unspecified(src->addr))
         len = (uint16_t)(len + 8);
 
-    sol = pico_proto_ipv6.alloc(&pico_proto_ipv6, len);
+    sol = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, len);
     if (!sol) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -419,8 +414,6 @@ int pico_icmp6_router_solicitation(struct pico_device *dev, struct pico_ip6 *src
         lladdr->len = 1;
         memcpy(lladdr->addr.mac.addr, dev->eth->mac.addr, PICO_SIZE_ETH);
     }
-
-    sol->dev = dev;
 
     /* f->src is set in frame_push, checksum calculated there */
     pico_ipv6_frame_push(sol, NULL, &daddr, PICO_PROTO_ICMP6, 0);
@@ -443,7 +436,7 @@ int pico_icmp6_router_advertisement(struct pico_device *dev, struct pico_ip6 *ds
 
     len = PICO_ICMP6HDR_ROUTER_ADV_SIZE + PICO_ICMP6_OPT_LLADDR_SIZE + sizeof(struct pico_icmp6_opt_prefix);
 
-    adv = pico_proto_ipv6.alloc(&pico_proto_ipv6, len);
+    adv = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, len);
     if (!adv) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -451,7 +444,6 @@ int pico_icmp6_router_advertisement(struct pico_device *dev, struct pico_ip6 *ds
 
     adv->payload = adv->transport_hdr + len;
     adv->payload_len = 0;
-    adv->dev = dev;
 
     icmp6_hdr = (struct pico_icmp6_hdr *)adv->transport_hdr;
     icmp6_hdr->type = PICO_ICMP6_ROUTER_ADV;
@@ -520,7 +512,7 @@ static int pico_icmp6_send_echo(struct pico_icmp6_ping_cookie *cookie)
     struct pico_frame *echo = NULL;
     struct pico_icmp6_hdr *hdr = NULL;
 
-    echo = pico_proto_ipv6.alloc(&pico_proto_ipv6, (uint16_t)(PICO_ICMP6HDR_ECHO_REQUEST_SIZE + cookie->size));
+    echo = pico_proto_ipv6.alloc(&pico_proto_ipv6, cookie->dev, (uint16_t)(PICO_ICMP6HDR_ECHO_REQUEST_SIZE + cookie->size));
     if (!echo) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -537,7 +529,6 @@ static int pico_icmp6_send_echo(struct pico_icmp6_ping_cookie *cookie)
     /* XXX: Fill payload */
     hdr->crc = 0;
     hdr->crc = short_be(pico_icmp6_checksum(echo));
-    echo->dev = cookie->dev;
     pico_ipv6_frame_push(echo, NULL, &cookie->dst, PICO_PROTO_ICMP6, 0);
     return 0;
 }

--- a/modules/pico_igmp.c
+++ b/modules/pico_igmp.c
@@ -697,14 +697,15 @@ static int8_t pico_igmpv3_generate_report(struct mcast_filter_parameters *filter
     struct igmpv3_report *report = NULL;
     struct igmpv3_group_record *record = NULL;
     struct pico_tree_node *index = NULL;
+    struct pico_device *dev = NULL;
     uint16_t len = 0;
     uint16_t i = 0;
     len = (uint16_t)(sizeof(struct igmpv3_report) + sizeof(struct igmpv3_group_record) + (filter->sources * sizeof(struct pico_ip4)));
-    p->f = pico_proto_ipv4.alloc(&pico_proto_ipv4, (uint16_t)(IP_OPTION_ROUTER_ALERT_LEN + len));
+    dev = pico_ipv4_link_find((struct pico_ip4 *)&p->mcast_link);
+    p->f = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, (uint16_t)(IP_OPTION_ROUTER_ALERT_LEN + len));
     p->f->net_len = (uint16_t)(p->f->net_len + IP_OPTION_ROUTER_ALERT_LEN);
     p->f->transport_hdr += IP_OPTION_ROUTER_ALERT_LEN;
     p->f->transport_len = (uint16_t)(p->f->transport_len - IP_OPTION_ROUTER_ALERT_LEN);
-    p->f->dev = pico_ipv4_link_find((struct pico_ip4 *)&p->mcast_link);
     /* p->f->len is correctly set by alloc */
 
     report = (struct igmpv3_report *)p->f->transport_hdr;
@@ -740,14 +741,15 @@ static int8_t pico_igmpv2_generate_report(struct mcast_parameters *p)
 {
     struct igmp_message *report = NULL;
     uint8_t report_type = IGMP_TYPE_MEM_REPORT_V2;
+    struct pico_device *dev = NULL;
     if (p->event == IGMP_EVENT_DELETE_GROUP)
         report_type = IGMP_TYPE_LEAVE_GROUP;
 
-    p->f = pico_proto_ipv4.alloc(&pico_proto_ipv4, IP_OPTION_ROUTER_ALERT_LEN + sizeof(struct igmp_message));
+    dev = pico_ipv4_link_find((struct pico_ip4 *)&p->mcast_link);
+    p->f = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, IP_OPTION_ROUTER_ALERT_LEN + sizeof(struct igmp_message));
     p->f->net_len = (uint16_t)(p->f->net_len + IP_OPTION_ROUTER_ALERT_LEN);
     p->f->transport_hdr += IP_OPTION_ROUTER_ALERT_LEN;
     p->f->transport_len = (uint16_t)(p->f->transport_len - IP_OPTION_ROUTER_ALERT_LEN);
-    p->f->dev = pico_ipv4_link_find((struct pico_ip4 *)&p->mcast_link);
     /* p->f->len is correctly set by alloc */
 
     report = (struct igmp_message *)p->f->transport_hdr;

--- a/modules/pico_ipv4.c
+++ b/modules/pico_ipv4.c
@@ -22,6 +22,7 @@
 #include "pico_aodv.h"
 #include "pico_socket_multicast.h"
 #include "pico_fragments.h"
+#include "pico_ethernet.h"
 #include "pico_mcast.h"
 
 #ifdef PICO_SUPPORT_IPV4
@@ -48,7 +49,7 @@ static struct pico_queue out = {
 
 /* Functions */
 static int ipv4_route_compare(void *ka, void *kb);
-static struct pico_frame *pico_ipv4_alloc(struct pico_protocol *self, uint16_t size);
+static struct pico_frame *pico_ipv4_alloc(struct pico_protocol *self, struct pico_device *dev, uint16_t size);
 
 
 int pico_ipv4_compare(struct pico_ip4 *a, struct pico_ip4 *b)
@@ -479,20 +480,24 @@ static int pico_ipv4_process_out(struct pico_protocol *self, struct pico_frame *
 }
 
 
-static struct pico_frame *pico_ipv4_alloc(struct pico_protocol *self, uint16_t size)
+static struct pico_frame *pico_ipv4_alloc(struct pico_protocol *self, struct pico_device *dev, uint16_t size)
 {
-    struct pico_frame *f =  pico_frame_alloc(size + PICO_SIZE_IP4HDR + PICO_SIZE_ETHHDR);
+    struct pico_frame *f = NULL;
     IGNORE_PARAMETER(self);
+
+    f = pico_proto_ethernet.alloc(&pico_proto_ethernet, dev, (uint16_t)(size + PICO_SIZE_IP4HDR));
+    /* TODO: In 6LoWPAN topic branch update to make use of dev->ll_mode */
 
     if (!f)
         return NULL;
 
-    f->datalink_hdr = f->buffer;
-    f->net_hdr = f->buffer + PICO_SIZE_ETHHDR;
     f->net_len = PICO_SIZE_IP4HDR;
     f->transport_hdr = f->net_hdr + PICO_SIZE_IP4HDR;
-    f->transport_len = size;
-    f->len =  size + PICO_SIZE_IP4HDR;
+    f->transport_len = (uint16_t)size;
+
+    /* Datalink size is accounted for in pico_datalink_send (link layer) */
+    f->len =  (uint32_t)(size + PICO_SIZE_IP4HDR);
+
     return f;
 }
 
@@ -1438,7 +1443,7 @@ static int pico_ipv4_rebound_large(struct pico_frame *f)
         if (space > PICO_IPV4_MAXPAYLOAD)
             space = PICO_IPV4_MAXPAYLOAD;
 
-        fr = pico_ipv4_alloc(&pico_proto_ipv4, (uint16_t)space);
+        fr = pico_ipv4_alloc(&pico_proto_ipv4, NULL, (uint16_t)space);
         if (!fr) {
             pico_err = PICO_ERR_ENOMEM;
             return -1;

--- a/modules/pico_ipv6.c
+++ b/modules/pico_ipv6.c
@@ -17,6 +17,7 @@
 #include "pico_device.h"
 #include "pico_tree.h"
 #include "pico_fragments.h"
+#include "pico_ethernet.h"
 #include "pico_mld.h"
 #include "pico_mcast.h"
 #ifdef PICO_SUPPORT_IPV6
@@ -878,22 +879,30 @@ static int pico_ipv6_process_out(struct pico_protocol *self, struct pico_frame *
  * increment net_len and transport_hdr with the len of the extension headers, decrement
  * transport_len with this value.
  */
-static struct pico_frame *pico_ipv6_alloc(struct pico_protocol *self, uint16_t size)
+static struct pico_frame *pico_ipv6_alloc(struct pico_protocol *self, struct pico_device *dev, uint16_t size)
 {
-    struct pico_frame *f =  pico_frame_alloc((uint32_t)(size + PICO_SIZE_IP6HDR + PICO_SIZE_ETHHDR));
+    struct pico_frame *f = NULL;
 
     IGNORE_PARAMETER(self);
+
+    f = pico_proto_ethernet.alloc(&pico_proto_ethernet, dev, (uint16_t)(size + PICO_SIZE_IP6HDR));
+#ifdef PICO_SUPPORT_6LOWPAN
+    /* TODO: For in 6LoWPAN branch */
+    else if (LL_MODE_6LOWPAN == dev->mode) {
+        f = pico_proto_ieee802154.alloc(pico_proto_ieee802154, dev, size + PICO_SIZE_IP6HDR);
+    }
+#endif
 
     if (!f)
         return NULL;
 
-    f->datalink_hdr = f->buffer;
-    f->net_hdr = f->buffer + PICO_SIZE_ETHHDR;
     f->net_len = PICO_SIZE_IP6HDR;
     f->transport_hdr = f->net_hdr + PICO_SIZE_IP6HDR;
     f->transport_len = (uint16_t)size;
-    /* PICO_SIZE_ETHHDR is accounted for in pico_ethernet_send */
+
+    /* Datalink size is accounted for in pico_datalink_send (link layer) */
     f->len =  (uint32_t)(size + PICO_SIZE_IP6HDR);
+
     return f;
 }
 

--- a/modules/pico_mld.c
+++ b/modules/pico_mld.c
@@ -632,10 +632,9 @@ static int8_t pico_mld_send_done(struct mcast_parameters *p, struct pico_frame *
 {
     struct mld_message *report = NULL;
     uint8_t report_type = PICO_MLD_DONE;
+    struct pico_device *dev = NULL;
     struct pico_ipv6_exthdr *hbh;
-    struct pico_ip6 dst = {{
-                               0
-                           }};
+    struct pico_ip6 dst = {{ 0 }};
 #ifdef PICO_DEBUG_MLD
     char ipstr[PICO_IPV6_STRING] = {
         0
@@ -645,8 +644,8 @@ static int8_t pico_mld_send_done(struct mcast_parameters *p, struct pico_frame *
 #endif
     IGNORE_PARAMETER(f);
     pico_string_to_ipv6(MLD_ALL_ROUTER_GROUP, &dst.addr[0]);
-    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN);
-    p->f->dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN);
     /* p->f->len is correctly set by alloc */
     hbh = (struct pico_ipv6_exthdr *)(p->f->transport_hdr);
     report = (struct mld_message *)(pico_mld_fill_hopbyhop((struct pico_ipv6_hbhoption*)hbh));
@@ -720,6 +719,7 @@ static int8_t pico_mldv2_generate_report(struct mcast_filter_parameters *filter,
     struct mldv2_group_record *record = NULL;
     struct pico_tree_node *index = NULL;
     struct pico_ipv6_hbhoption *hbh;
+    struct pico_device *dev = NULL;
     uint16_t len = 0;
     uint16_t i = 0;
     /* RFC3810 $5.1.10 */
@@ -731,8 +731,8 @@ static int8_t pico_mldv2_generate_report(struct mcast_filter_parameters *filter,
     len = (uint16_t)(sizeof(struct mldv2_report) + sizeof(struct mldv2_group_record) \
                      + (filter->sources * sizeof(struct pico_ip6)) + MLD_ROUTER_ALERT_LEN);
     len = (uint16_t)(len - sizeof(struct pico_ip6));
-    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, len);
-    p->f->dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, len);
     /* p->f->len is correctly set by alloc */
 
     hbh = (struct pico_ipv6_hbhoption *) p->f->transport_hdr;
@@ -794,8 +794,8 @@ static int8_t pico_mldv1_generate_report(struct mcast_parameters *p)
     struct mld_message *report = NULL;
     uint8_t report_type = PICO_MLD_REPORT;
     struct pico_ipv6_exthdr *hbh;
-    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN );
-    p->f->dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    struct pico_device *dev = pico_ipv6_link_find(&p->mcast_link.ip6);
+    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN );
     /* p->f->len is correctly set by alloc */
 
     hbh = (struct pico_ipv6_exthdr *)(p->f->transport_hdr);

--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -1188,7 +1188,7 @@ int pico_tcp_initconn(struct pico_socket *s)
     struct pico_tcp_hdr *hdr;
     uint16_t mtu, opt_len = tcp_options_size(ts, PICO_TCP_SYN);
 
-    syn = s->net->alloc(s->net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    syn = s->net->alloc(s->net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
     if (!syn)
         return -1;
 
@@ -1229,7 +1229,7 @@ static int tcp_send_synack(struct pico_socket *s)
     struct pico_tcp_hdr *hdr;
     uint16_t opt_len = tcp_options_size(ts, PICO_TCP_SYN | PICO_TCP_ACK);
 
-    synack = s->net->alloc(s->net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    synack = s->net->alloc(s->net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
     if (!synack)
         return -1;
 
@@ -1256,7 +1256,7 @@ static void tcp_send_empty(struct pico_socket_tcp *t, uint16_t flags, int is_kee
     struct pico_frame *f;
     struct pico_tcp_hdr *hdr;
     uint16_t opt_len = tcp_options_size(t, flags);
-    f = t->sock.net->alloc(t->sock.net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    f = t->sock.net->alloc(t->sock.net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
     if (!f) {
         return;
     }
@@ -1306,7 +1306,7 @@ static int tcp_do_send_rst(struct pico_socket *s, uint32_t seq)
     uint16_t opt_len = tcp_options_size(t, PICO_TCP_RST);
     struct pico_frame *f;
     struct pico_tcp_hdr *hdr;
-    f = t->sock.net->alloc(t->sock.net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    f = t->sock.net->alloc(t->sock.net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
     if (!f) {
         return -1;
     }
@@ -1422,7 +1422,7 @@ int pico_tcp_reply_rst(struct pico_frame *fr)
 
     tcp_dbg("TCP> sending RST ... \n");
 
-    f = fr->sock->net->alloc(fr->sock->net, size);
+    f = fr->sock->net->alloc(fr->sock->net, NULL, size);
     if (!f) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -1470,7 +1470,7 @@ static int tcp_nosync_rst(struct pico_socket *s, struct pico_frame *fr)
 
     /***************************************************************************/
     /* sending RST */
-    f = t->sock.net->alloc(t->sock.net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    f = t->sock.net->alloc(t->sock.net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
 
     if (!f) {
         return -1;
@@ -1525,7 +1525,7 @@ static void tcp_send_fin(struct pico_socket_tcp *t)
     struct pico_frame *f;
     struct pico_tcp_hdr *hdr;
     uint16_t opt_len = tcp_options_size(t, PICO_TCP_FIN);
-    f = t->sock.net->alloc(t->sock.net, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
+    f = t->sock.net->alloc(t->sock.net, NULL, (uint16_t)(PICO_SIZE_TCPHDR + opt_len));
     if (!f) {
         return;
     }
@@ -2822,8 +2822,8 @@ static struct pico_frame *tcp_split_segment(struct pico_socket_tcp *t, struct pi
     size1 = size;
     size2 = (uint16_t)(size_f - size);
 
-    f1 = pico_socket_frame_alloc(&t->sock, (uint16_t) (size1 + overhead));
-    f2 = pico_socket_frame_alloc(&t->sock, (uint16_t) (size2 + overhead));
+    f1 = pico_socket_frame_alloc(&t->sock, get_sock_dev(&t->sock), (uint16_t) (size1 + overhead));
+    f2 = pico_socket_frame_alloc(&t->sock, get_sock_dev(&t->sock), (uint16_t) (size2 + overhead));
 
     if (!f1 || !f2) {
         pico_err = PICO_ERR_ENOMEM;
@@ -2971,7 +2971,7 @@ static struct pico_frame *pico_hold_segment_make(struct pico_socket_tcp *t)
             break;
     }
     /* alloc new frame with payload size = off + total_len */
-    f_new = pico_socket_frame_alloc(s, (uint16_t)(off + total_len));
+    f_new = pico_socket_frame_alloc(s, get_sock_dev(s), (uint16_t)(off + total_len));
     if (!f_new) {
         pico_err = PICO_ERR_ENOMEM;
         return f_new;

--- a/stack/pico_frame.c
+++ b/stack/pico_frame.c
@@ -125,17 +125,16 @@ struct pico_frame *pico_frame_alloc(uint32_t size)
     return pico_frame_do_alloc(size, 0, 0);
 }
 
-int pico_frame_grow(struct pico_frame *f, uint32_t size)
+static uint8_t *
+pico_frame_new_buffer(struct pico_frame *f, uint32_t size, uint32_t *oldsize)
 {
     uint8_t *oldbuf;
     uint32_t usage_count, *p_old_usage;
     uint32_t frame_buffer_size;
-    uint32_t oldsize;
     unsigned int align;
-    int addr_diff = 0;
 
     if (!f || (size < f->buffer_len)) {
-        return -1;
+        return NULL;
     }
 
     align = size % sizeof(uint32_t);
@@ -145,22 +144,28 @@ int pico_frame_grow(struct pico_frame *f, uint32_t size)
     }
 
     oldbuf = f->buffer;
-    oldsize = f->buffer_len;
+    *oldsize = f->buffer_len;
     usage_count = *(f->usage_count);
     p_old_usage = f->usage_count;
     f->buffer = PICO_ZALLOC(frame_buffer_size + sizeof(uint32_t));
     if (!f->buffer) {
         f->buffer = oldbuf;
-        return -1;
+        return NULL;
     }
 
     f->usage_count = (uint32_t *)(((uint8_t*)f->buffer) + frame_buffer_size);
     *f->usage_count = usage_count;
     f->buffer_len = size;
-    memcpy(f->buffer, oldbuf, oldsize);
 
-    /* Update hdr fields to new buffer*/
-    addr_diff = (int)(f->buffer - oldbuf);
+    if (f->flags & PICO_FRAME_FLAG_EXT_USAGE_COUNTER)
+        PICO_FREE(p_old_usage);
+    /* Now, the frame is not zerocopy anymore, and the usage counter has been moved within it */
+    return oldbuf;
+}
+
+static int
+pico_frame_update_pointers(struct pico_frame *f, int addr_diff, uint8_t *oldbuf)
+{
     f->net_hdr += addr_diff;
     f->datalink_hdr += addr_diff;
     f->transport_hdr += addr_diff;
@@ -168,17 +173,43 @@ int pico_frame_grow(struct pico_frame *f, uint32_t size)
     f->start += addr_diff;
     f->payload += addr_diff;
 
-    if (f->flags & PICO_FRAME_FLAG_EXT_USAGE_COUNTER)
-        PICO_FREE(p_old_usage);
-
     if (!(f->flags & PICO_FRAME_FLAG_EXT_BUFFER))
         PICO_FREE(oldbuf);
     else if (f->notify_free)
         f->notify_free(oldbuf);
 
     f->flags = 0;
-    /* Now, the frame is not zerocopy anymore, and the usage counter has been moved within it */
     return 0;
+}
+
+int pico_frame_grow_head(struct pico_frame *f, uint32_t size)
+{
+    int addr_diff = 0;
+    uint32_t oldsize = 0;
+    uint8_t *oldbuf = pico_frame_new_buffer(f, size, &oldsize);
+    if (!oldbuf)
+        return -1;
+
+    /* Put old buffer at the end of new buffer */
+    memcpy(f->buffer + f->buffer_len - oldsize, oldbuf, oldsize);
+    addr_diff = (int)((f->buffer + f->buffer_len - oldsize) - oldbuf);
+
+    return pico_frame_update_pointers(f, addr_diff, oldbuf);
+}
+
+int pico_frame_grow(struct pico_frame *f, uint32_t size)
+{
+    int addr_diff = 0;
+    uint32_t oldsize = 0;
+    uint8_t *oldbuf = pico_frame_new_buffer(f, size, &oldsize);
+    if (!oldbuf)
+        return -1;
+
+    /* Just put old buffer at the beginning of new buffer */
+    memcpy(f->buffer, oldbuf, oldsize);
+    addr_diff = (int)(f->buffer - oldbuf);
+
+    return pico_frame_update_pointers(f, addr_diff, oldbuf);
 }
 
 struct pico_frame *pico_frame_alloc_skeleton(uint32_t size, int ext_buffer)

--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -51,7 +51,7 @@ static void *Mutex = NULL;
 
 static struct pico_sockport *sp_udp = NULL, *sp_tcp = NULL;
 
-struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, uint16_t len);
+struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, struct pico_device *dev, uint16_t len);
 
 static int socket_cmp_family(struct pico_socket *a, struct pico_socket *b)
 {
@@ -1047,11 +1047,24 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
                                 struct pico_remote_endpoint *ep, struct pico_msginfo *msginfo)
 {
     struct pico_frame *f;
+    struct pico_device *dev = NULL;
     uint16_t hdr_offset = (uint16_t)pico_socket_sendto_transport_offset(s);
     int ret = 0;
     (void)src;
 
-    f = pico_socket_frame_alloc(s, (uint16_t)(len + hdr_offset));
+    if (msginfo)
+        dev = msginfo->dev;
+
+#ifdef PICO_SUPPORT_IPV6
+    if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
+        dev = pico_ipv6_link_find(src);
+        if(!dev) {
+            return -1;
+        }
+    }
+#endif
+
+    f = pico_socket_frame_alloc(s, dev, (uint16_t)(len + hdr_offset));
     if (!f) {
         pico_err = PICO_ERR_ENOMEM;
         return -1;
@@ -1073,18 +1086,8 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
     if (msginfo) {
         f->send_ttl = (uint8_t)msginfo->ttl;
         f->send_tos = (uint8_t)msginfo->tos;
-        f->dev = msginfo->dev;
     }
 
-#ifdef PICO_SUPPORT_IPV6
-    if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
-        f->dev = pico_ipv6_link_find(src);
-        if(!f->dev) {
-            return -1;
-        }
-    }
-
-#endif
     memcpy(f->payload, (const uint8_t *)buf, f->payload_len);
     /* dbg("Pushing segment, hdr len: %d, payload_len: %d\n", header_offset, f->payload_len); */
     ret = pico_socket_final_xmit(s, f);
@@ -1160,7 +1163,7 @@ static int pico_socket_xmit_fragments(struct pico_socket *s, const void *buf, co
         if (space > len - total_payload_written) /* update space for last fragment */
             space = len - total_payload_written;
 
-        f = pico_socket_frame_alloc(s, (uint16_t)(space + hdr_offset));
+        f = pico_socket_frame_alloc(s, get_sock_dev(s), (uint16_t)(space + hdr_offset));
         if (!f) {
             pico_err = PICO_ERR_ENOMEM;
             pico_endpoint_free(ep);
@@ -1215,7 +1218,7 @@ static int pico_socket_xmit_fragments(struct pico_socket *s, const void *buf, co
 #endif
 }
 
-static void get_sock_dev(struct pico_socket *s)
+struct pico_device *get_sock_dev(struct pico_socket *s)
 {
     if (0) {}
 
@@ -1228,6 +1231,7 @@ static void get_sock_dev(struct pico_socket *s)
         s->dev = pico_ipv4_source_dev_find(&s->remote_addr.ip4);
 #endif
 
+    return s->dev;
 }
 
 
@@ -2133,19 +2137,19 @@ int pico_count_sockets(uint8_t proto)
 }
 
 
-struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, uint16_t len)
+struct pico_frame *pico_socket_frame_alloc(struct pico_socket *s, struct pico_device *dev, uint16_t len)
 {
     struct pico_frame *f = NULL;
 
 #ifdef PICO_SUPPORT_IPV6
     if (is_sock_ipv6(s))
-        f = pico_proto_ipv6.alloc(&pico_proto_ipv6, len);
+        f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, len);
 
 #endif
 
 #ifdef PICO_SUPPORT_IPV4
     if (is_sock_ipv4(s))
-        f = pico_proto_ipv4.alloc(&pico_proto_ipv4, len);
+        f = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, len);
 
 #endif
     if (!f) {

--- a/test/unit/modunit_pico_frame.c
+++ b/test/unit/modunit_pico_frame.c
@@ -49,6 +49,27 @@ START_TEST(tc_pico_frame_alloc_discard)
 }
 END_TEST
 
+START_TEST(tc_pico_frame_grow_head)
+{
+    struct pico_frame *f = pico_frame_alloc(3);
+    int ret = 0;
+    uint8_t buf[6] = { 0, 0, 0, 'a', 'b', 'c'};
+
+    /* I don't care about usage_count, it's tested 'pico_frame_grow' */
+
+    f->net_hdr = f->buffer;
+    f->net_len = 3;
+    f->net_hdr[0] = 'a';
+    f->net_hdr[1] = 'b';
+    f->net_hdr[2] = 'c';
+
+    /* Try to grow head */
+    ret = pico_frame_grow_head(f, 6);
+    fail_unless(0 == memcmp(f->buffer, buf, f->buffer_len));
+    fail_unless(3 == f->net_hdr - f->buffer);
+}
+END_TEST
+
 START_TEST(tc_pico_frame_grow)
 {
     struct pico_frame *f = pico_frame_alloc(3);
@@ -205,18 +226,21 @@ Suite *pico_suite(void)
     TCase *TCase_pico_frame_alloc_discard = tcase_create("Unit test for pico_frame_alloc_discard");
     TCase *TCase_pico_frame_copy = tcase_create("Unit test for pico_frame_copy");
     TCase *TCase_pico_frame_grow = tcase_create("Unit test for pico_frame_grow");
+    TCase *TCase_pico_frame_grow_head = tcase_create("Unit test for pico_frame_grow_head");
     TCase *TCase_pico_frame_deepcopy = tcase_create("Unit test for pico_frame_deepcopy");
     TCase *TCase_pico_is_digit = tcase_create("Unit test for pico_is_digit");
     TCase *TCase_pico_is_hex = tcase_create("Unit test for pico_is_hex");
     tcase_add_test(TCase_pico_frame_alloc_discard, tc_pico_frame_alloc_discard);
     tcase_add_test(TCase_pico_frame_copy, tc_pico_frame_copy);
     tcase_add_test(TCase_pico_frame_grow, tc_pico_frame_grow);
+    tcase_add_test(TCase_pico_frame_grow_head, tc_pico_frame_grow_head);
     tcase_add_test(TCase_pico_frame_deepcopy, tc_pico_frame_deepcopy);
     tcase_add_test(TCase_pico_is_digit, tc_pico_is_digit);
     tcase_add_test(TCase_pico_is_hex, tc_pico_is_hex);
     suite_add_tcase(s, TCase_pico_frame_alloc_discard);
     suite_add_tcase(s, TCase_pico_frame_copy);
     suite_add_tcase(s, TCase_pico_frame_grow);
+    suite_add_tcase(s, TCase_pico_frame_grow_head);
     suite_add_tcase(s, TCase_pico_frame_deepcopy);
     return s;
 }

--- a/test/unit/modunit_pico_igmp.c
+++ b/test/unit/modunit_pico_igmp.c
@@ -205,7 +205,7 @@ START_TEST(tc_pico_igmp_compatibility_mode)
     struct pico_ipv4_hdr *hdr;
     struct igmp_message *query;
     uint8_t ihl = 24;
-    f = pico_proto_ipv4.alloc(&pico_proto_ipv4, sizeof(struct igmpv3_report) + sizeof(struct igmpv3_group_record) + (0 * sizeof(struct pico_ip4)));
+    f = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, sizeof(struct igmpv3_report) + sizeof(struct igmpv3_group_record) + (0 * sizeof(struct pico_ip4)));
     pico_string_to_ipv4("192.168.1.2", &addr.addr);
     hdr = (struct pico_ipv4_hdr *) f->net_hdr;
     ihl = (uint8_t)((hdr->vhl & 0x0F) * 4); /* IHL is in 32bit words */
@@ -235,7 +235,7 @@ START_TEST(tc_pico_igmp_analyse_packet)
     struct pico_ip4 addr;
     struct pico_ipv4_hdr *ip4;
     struct igmp_message *igmp;
-    f = pico_proto_ipv4.alloc(&pico_proto_ipv4, sizeof(struct igmp_message));
+    f = pico_proto_ipv4.alloc(&pico_proto_ipv4, dev, sizeof(struct igmp_message));
     pico_string_to_ipv4("192.168.1.1", &addr.addr);
     /* No link */
     fail_if(pico_igmp_analyse_packet(f) != NULL);

--- a/test/unit/modunit_pico_mld.c
+++ b/test/unit/modunit_pico_mld.c
@@ -100,7 +100,7 @@ START_TEST(tc_pico_mld_send_report)
     struct pico_ip6 addr;
     struct pico_ipv6_link *link;
     struct mcast_parameters p;
-    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
+    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
     pico_string_to_ipv6("AAAA::110", addr.addr);
     p.mcast_link.ip6 = addr;
     /* No link */
@@ -148,7 +148,7 @@ END_TEST
 START_TEST(tc_pico_mld_is_checksum_valid)
 {
     struct pico_frame *f;
-    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
+    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, NULL, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
     fail_if(pico_mld_is_checksum_valid(f) == 1);
 }
 END_TEST
@@ -300,7 +300,7 @@ START_TEST(tc_mld_mrsrrt)
     /* wrong proto */
     fail_if(mld_mrsrrt(p) != -1);
     link->mcast_compatibility = PICO_MLDV2;
-    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
+    p->f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
     fail_if(mld_mrsrrt(p) != -1);
 
 }
@@ -407,7 +407,7 @@ START_TEST(tc_pico_mld_compatibility_mode)
     struct pico_device *dev = pico_null_create("ummy1");
     struct pico_ip6 addr;
 
-    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
+    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, NULL, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
     pico_string_to_ipv6("AAAA::104", addr.addr);
     /* No link */
     fail_if(pico_mld_compatibility_mode(f) != -1);
@@ -460,20 +460,18 @@ END_TEST
 START_TEST(tc_pico_mld_analyse_packet)
 {
     struct pico_frame *f;
-
     struct pico_device *dev = pico_null_create("dummy0");
     struct pico_ip6 addr;
     struct pico_ip6 local;
     struct pico_ipv6_hdr *ip6;
     struct pico_ipv6_hbhoption *hbh;
     struct pico_icmp6_hdr *mld;
-    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN);
+    f = pico_proto_ipv6.alloc(&pico_proto_ipv6, dev, sizeof(struct mld_message) + MLD_ROUTER_ALERT_LEN);
     pico_string_to_ipv6("AAAA::108", addr.addr);
     pico_string_to_ipv6("FE80::1", local.addr);
     /* No link */
     fail_if(pico_mld_analyse_packet(f) != NULL);
     pico_ipv6_link_add(dev, addr, addr);
-    f->dev = dev;
     ip6 = f->net_hdr;
     ip6->hop == 99;
     /* Incorrect hop */

--- a/test/unit/unit_ipv4.c
+++ b/test/unit/unit_ipv4.c
@@ -77,7 +77,7 @@ START_TEST (test_nat_enable_disable)
     struct pico_ipv4_link link = {
         .address = {.addr = long_be(0x0a320001)}
     };                                                                       /* 10.50.0.1 */
-    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, PICO_UDPHDR_SIZE);
+    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, NULL, PICO_UDPHDR_SIZE);
     struct pico_ipv4_hdr *net = (struct pico_ipv4_hdr *)f->net_hdr;
     struct pico_udp_hdr *udp = (struct pico_udp_hdr *)f->transport_hdr;
     char *raw_data = "ello";
@@ -122,7 +122,7 @@ START_TEST (test_nat_translation)
     struct pico_ipv4_link link = {
         .address = {.addr = long_be(0x0a320001)}
     };                                                                       /* 10.50.0.1 */
-    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, PICO_UDPHDR_SIZE);
+    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, NULL, PICO_UDPHDR_SIZE);
     struct pico_ipv4_hdr *net = (struct pico_ipv4_hdr *)f->net_hdr;
     struct pico_udp_hdr *udp = (struct pico_udp_hdr *)f->transport_hdr;
     struct pico_ip4 src_ori = {
@@ -203,7 +203,7 @@ START_TEST (test_nat_port_forwarding)
     struct pico_ipv4_link link = {
         .address = {.addr = long_be(0x0a320001)}
     };                                                                       /* 10.50.0.1 */
-    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, PICO_UDPHDR_SIZE);
+    struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, NULL, PICO_UDPHDR_SIZE);
     struct pico_ipv4_hdr *net = (struct pico_ipv4_hdr *)f->net_hdr;
     struct pico_udp_hdr *udp = (struct pico_udp_hdr *)f->transport_hdr;
     struct pico_ip4 src_addr = {


### PR DESCRIPTION
Added 'device'-param to pico_protocol's alloc-function. This to alloc frames with overhead based on link layer and device's overhead-field. Should fix #405 and #376