### PR TITLE
Bugfix for compilation under macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 -include ../../config.mk
 -include ../../tools/kconfig/.config
 
+OS:=$(shell uname)
+
 CC:=$(CROSS_COMPILE)gcc
 LD:=$(CROSS_COMPILE)ld
 AR:=$(CROSS_COMPILE)ar
@@ -9,6 +11,20 @@ SIZE:=$(CROSS_COMPILE)size
 STRIP_BIN:=$(CROSS_COMPILE)strip
 TEST_LDFLAGS=-pthread  $(PREFIX)/modules/*.o $(PREFIX)/lib/*.o -lvdeplug
 LIBNAME:="libpicotcp.a"
+
+ifeq ($(OS),Darwin)
+  DU:=stat
+  DU_FLAGS:=-f%z
+else
+  DU:=du
+  DU_FLAGS:=-b
+endif
+
+ifeq ($(OS),Darwin)
+  SIZE_FLAGS:=
+else
+  SIZE_FLAGS:=-t
+endif
 
 PREFIX?=$(PWD)/build
 DEBUG?=1
@@ -353,8 +369,8 @@ lib: mod core
 	@test $(STRIP) -eq 1 && (echo -e "\t[STRIP] $(PREFIX)/lib/$(LIBNAME)" \
      && $(STRIP_BIN) $(PREFIX)/lib/$(LIBNAME)) \
      || echo -e "\t[KEEP SYMBOLS] $(PREFIX)/lib/$(LIBNAME)"
-	@echo -e "\t[LIBSIZE] `du -b $(PREFIX)/lib/$(LIBNAME)`"
-	@echo -e "`size -t $(PREFIX)/lib/$(LIBNAME)`"
+	@echo -e "\t[LIBSIZE] `$(DU) $(DU_FLAGS) $(PREFIX)/lib/$(LIBNAME)`"
+	@echo -e "`$(SIZE) $(SIZE_FLAGS) $(PREFIX)/lib/$(LIBNAME)`"
 
 loop: mod core
 	mkdir -p $(PREFIX)/test


### PR DESCRIPTION
Under macOS, one may observe the following errors:

```bash
du: illegal option -- b
usage: du [-H | -L | -P] [-a | -s | -d depth] [-c] [-h | -k | -m | -g] [-x] [-I mask] [file ...]
-e 	[LIBSIZE]
size: Unknown command line argument '-t'.  Try: '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/size -help'
size: Did you mean '-A'?
```

This is due to:
* `du` does not support `-b` under macOS. The same output can be emulated using `stat -f%z`
* `size` does not obey the `$(CROSS_COMPILE)` variable and it also does not know `-t`. This is only the case using Xcode toolchain (not arm-gcc-embedded).

This is probably a bug report with a PR to point at the right direction. I'm no Makefile expert, so I think this could be improved.