### PR TITLE
Warnings unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ SIZE:=$(CROSS_COMPILE)size
 STRIP_BIN:=$(CROSS_COMPILE)strip
 TEST_LDFLAGS=-pthread  $(PREFIX)/modules/*.o $(PREFIX)/lib/*.o -lvdeplug
 UNIT_LDFLAGS=-lcheck -lm -pthread -lrt -lsubunit
+UNIT_CFLAGS= $(CFLAGS) -Wno-missing-braces
+
 LIBNAME:="libpicotcp.a"
 
 PREFIX?=$(PWD)/build
@@ -365,34 +367,34 @@ units: mod core lib $(UNITS_OBJ) $(MOD_OBJ)
 	@echo -e "\n\t[UNIT TESTS SUITE]"
 	@mkdir -p $(PREFIX)/test
 	@echo -e "\t[CC] units.o"
-	@$(CC) -g -c -o $(PREFIX)/test/units.o test/units.c $(CFLAGS) -I stack -I modules -I includes -I test/unit -DUNIT_TEST
+	@$(CC) -g -c -o $(PREFIX)/test/units.o test/units.c $(UNIT_CFLAGS) -I stack -I modules -I includes -I test/unit -DUNIT_TEST
 	@echo -e "\t[LD] $(PREFIX)/test/units"
-	@$(CC) -o $(PREFIX)/test/units $(CFLAGS) $(PREFIX)/test/units.o $(UNIT_LDFLAGS) \
+	@$(CC) -o $(PREFIX)/test/units $(UNIT_CFLAGS) $(PREFIX)/test/units.o $(UNIT_LDFLAGS) \
 	   $(UNITS_OBJ) $(PREFIX)/modules/pico_aodv.o \
 	   $(PREFIX)/modules/pico_fragments.o
-	@$(CC) -o $(PREFIX)/test/modunit_pico_protocol.elf $(CFLAGS) -I. test/unit/modunit_pico_protocol.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_pico_frame.elf $(CFLAGS) -I. test/unit/modunit_pico_frame.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_seq.elf $(CFLAGS) -I. test/unit/modunit_seq.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_tcp.elf $(CFLAGS) -I. test/unit/modunit_pico_tcp.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_dns_client.elf $(CFLAGS) -I. test/unit/modunit_pico_dns_client.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_dns_common.elf $(CFLAGS) -I. test/unit/modunit_pico_dns_common.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_mdns.elf $(CFLAGS) -I. test/unit/modunit_pico_mdns.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_dns_sd.elf $(CFLAGS) -I. test/unit/modunit_pico_dns_sd.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_dev_loop.elf $(CFLAGS) -I. test/unit/modunit_pico_dev_loop.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_ipv6_nd.elf $(CFLAGS) -I. test/unit/modunit_pico_ipv6_nd.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_ethernet.elf $(CFLAGS) -I. test/unit/modunit_pico_ethernet.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_pico_stack.elf $(CFLAGS) -I. test/unit/modunit_pico_stack.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_tftp.elf $(CFLAGS) -I. test/unit/modunit_pico_tftp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_sntp_client.elf $(CFLAGS) -I. test/unit/modunit_pico_sntp_client.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_ipfilter.elf $(CFLAGS) -I. test/unit/modunit_pico_ipfilter.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_aodv.elf $(CFLAGS) -I. test/unit/modunit_pico_aodv.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_fragments.elf $(CFLAGS) -I. test/unit/modunit_pico_fragments.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_queue.elf $(CFLAGS) -I. test/unit/modunit_queue.c  $(UNIT_LDFLAGS) $(UNITS_OBJ)
-	@$(CC) -o $(PREFIX)/test/modunit_dev_ppp.elf $(CFLAGS) -I. test/unit/modunit_pico_dev_ppp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_mld.elf $(CFLAGS) -I. test/unit/modunit_pico_mld.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_igmp.elf $(CFLAGS) -I. test/unit/modunit_pico_igmp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_hotplug_detection.elf $(CFLAGS) -I. test/unit/modunit_pico_hotplug_detection.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
-	@$(CC) -o $(PREFIX)/test/modunit_strings.elf $(CFLAGS) -I. test/unit/modunit_pico_strings.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_pico_protocol.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_protocol.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_pico_frame.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_frame.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_seq.elf $(UNIT_CFLAGS) -I. test/unit/modunit_seq.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_tcp.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_tcp.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_dns_client.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_dns_client.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_dns_common.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_dns_common.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_mdns.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_mdns.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_dns_sd.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_dns_sd.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_dev_loop.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_dev_loop.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_ipv6_nd.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_ipv6_nd.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_ethernet.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_ethernet.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_pico_stack.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_stack.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_tftp.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_tftp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_sntp_client.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_sntp_client.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_ipfilter.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_ipfilter.c stack/pico_tree.c $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_aodv.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_aodv.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_fragments.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_fragments.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_queue.elf $(UNIT_CFLAGS) -I. test/unit/modunit_queue.c  $(UNIT_LDFLAGS) $(UNITS_OBJ)
+	@$(CC) -o $(PREFIX)/test/modunit_dev_ppp.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_dev_ppp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_mld.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_mld.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_igmp.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_igmp.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_hotplug_detection.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_hotplug_detection.c  $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
+	@$(CC) -o $(PREFIX)/test/modunit_strings.elf $(UNIT_CFLAGS) -I. test/unit/modunit_pico_strings.c $(UNIT_LDFLAGS) $(UNITS_OBJ) $(PREFIX)/lib/libpicotcp.a
 
 devunits: mod core lib
 	@echo -e "\n\t[UNIT TESTS SUITE: device drivers]"

--- a/modules/pico_dev_null.c
+++ b/modules/pico_dev_null.c
@@ -39,7 +39,7 @@ static int pico_null_poll(struct pico_device *dev, int loop_score)
 /* Public interface: create/destroy. */
 
 
-struct pico_device *pico_null_create(char *name)
+struct pico_device *pico_null_create(const char *name)
 {
     struct pico_device_null *null = PICO_ZALLOC(sizeof(struct pico_device_null));
 

--- a/modules/pico_dev_null.h
+++ b/modules/pico_dev_null.h
@@ -9,7 +9,7 @@
 #include "pico_device.h"
 
 void pico_null_destroy(struct pico_device *null);
-struct pico_device *pico_null_create(char *name);
+struct pico_device *pico_null_create(const char *name);
 
 #endif
 

--- a/modules/pico_dns_common.c
+++ b/modules/pico_dns_common.c
@@ -208,7 +208,7 @@ pico_dns_url_to_reverse_qname( const char *url, uint8_t proto )
         return NULL;
     }
 
-    pico_dns_name_to_dns_notation(reverse_qname, (unsigned int)(slen + arpalen));
+    pico_dns_name_to_dns_notation(reverse_qname, (uint16_t)(slen + arpalen));
     return reverse_qname;
 }
 
@@ -305,13 +305,13 @@ pico_dns_strlen( const char *url )
  *  @param maxlen Maximum length of buffer so it doesn't cause a buffer overflow
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
-int pico_dns_name_to_dns_notation( char *url, unsigned int maxlen )
+int pico_dns_name_to_dns_notation( char *url, uint16_t maxlen )
 {
     char c = '\0';
     char *lbl = url, *i = url;
 
     /* Check params */
-    if (!url || pico_dns_check_namelen((uint16_t)maxlen)) {
+    if (!url || pico_dns_check_namelen(maxlen)) {
         pico_err = PICO_ERR_EINVAL;
         return -1;
     }
@@ -339,12 +339,12 @@ int pico_dns_name_to_dns_notation( char *url, unsigned int maxlen )
  *  @param maxlen Maximum length of buffer so it doesn't cause a buffer overflow
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
-int pico_dns_notation_to_name( char *ptr, unsigned int maxlen )
+int pico_dns_notation_to_name( char *ptr, uint16_t maxlen )
 {
     char *label = NULL, *next = NULL;
 
     /* Iterate safely over the labels and update each label */
-    dns_name_foreach_label_safe(label, ptr, next, (uint16_t)maxlen) {
+    dns_name_foreach_label_safe(label, ptr, next, maxlen) {
         *label = '.';
     }
 

--- a/modules/pico_dns_common.h
+++ b/modules/pico_dns_common.h
@@ -195,7 +195,7 @@ pico_dns_strlen( const char *url );
  *  @param maxlen Maximum length of buffer so it doesn't cause a buffer overflow
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
-int pico_dns_name_to_dns_notation( char *url, unsigned int maxlen );
+int pico_dns_name_to_dns_notation( char *url, uint16_t maxlen );
 
 /* ****************************************************************************
  *  Replaces the label lengths in a DNS-name by .'s. So it actually converts a
@@ -206,7 +206,7 @@ int pico_dns_name_to_dns_notation( char *url, unsigned int maxlen );
  *  @param maxlen Maximum length of buffer so it doesn't cause a buffer overflow
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
-int pico_dns_notation_to_name( char *ptr, unsigned int maxlen );
+int pico_dns_notation_to_name( char *ptr, uint16_t maxlen );
 
 /* ****************************************************************************
  *  Determines the length of the first label of a DNS name in URL-format

--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -13,6 +13,7 @@
 #include "pico_socket.h"
 #include "pico_stack.h"
 #include "pico_socket.h"
+#include "pico_socket_tcp.h"
 #include "pico_queue.h"
 #include "pico_tree.h"
 
@@ -42,8 +43,6 @@
 
 #define ONE_GIGABYTE ((uint32_t)(1024UL * 1024UL * 1024UL))
 
-/* check if the Nagle algorithm is enabled on the socket */
-#define IS_NAGLE_ENABLED(s)     (!(!(!(s->opt_flags & (1u << PICO_SOCKET_OPT_TCPNODELAY)))))
 /* check if tcp connection is "idle" according to Nagle (RFC 896) */
 #define IS_TCP_IDLE(t)          ((t->in_flight == 0) && (t->tcpq_out.size == 0))
 /* check if the hold queue contains data (again Nagle) */

--- a/test/unit/modunit_pico_dev_ppp.c
+++ b/test/unit/modunit_pico_dev_ppp.c
@@ -16,7 +16,7 @@ static enum ppp_lcp_event ppp_lcp_ev;
 static enum ppp_auth_event ppp_auth_ev;
 static enum ppp_ipcp_event ppp_ipcp_ev;
 
-static int called_picotimer =  0;
+static uint32_t called_picotimer =  0;
 
 Suite *pico_suite(void);
 
@@ -25,8 +25,10 @@ uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void
     IGNORE_PARAMETER(arg);
     IGNORE_PARAMETER(timer);
     IGNORE_PARAMETER(expire);
+
     called_picotimer++;
-    return NULL;
+
+    return called_picotimer;
 }
 
 
@@ -431,19 +433,19 @@ START_TEST(tc_ppp_modem_recv)
     char error[] = "ERROR";
     char blabla[] = "Blabla";
     ppp_modem_ev = 0;
-    ppp_modem_recv(&_ppp, ok, strlen(ok));
+    ppp_modem_recv(&_ppp, ok, (uint32_t)strlen(ok));
     fail_if(ppp_modem_ev != PPP_MODEM_EVENT_OK);
 
     ppp_modem_ev = 0;
-    ppp_modem_recv(&_ppp, connect, strlen(connect));
+    ppp_modem_recv(&_ppp, connect, (uint32_t)strlen(connect));
     fail_if(ppp_modem_ev != PPP_MODEM_EVENT_CONNECT);
 
     ppp_modem_ev = 0;
-    ppp_modem_recv(&_ppp, error, strlen(error));
+    ppp_modem_recv(&_ppp, error, (uint32_t)strlen(error));
     fail_if(ppp_modem_ev != PPP_MODEM_EVENT_STOP);
 
     ppp_modem_ev = PPP_MODEM_EVENT_MAX; /* Which is basically illegal, just to check */
-    ppp_modem_recv(&_ppp, blabla, 8);
+    ppp_modem_recv(&_ppp, blabla, (uint32_t)8);
     fail_if(ppp_modem_ev != PPP_MODEM_EVENT_MAX);
 
 }

--- a/test/unit/modunit_pico_dns_client.c
+++ b/test/unit/modunit_pico_dns_client.c
@@ -15,6 +15,8 @@ Suite *pico_suite(void);
 START_TEST(tc_pico_dns_client_callback)
 {
     struct pico_socket *s = pico_udp_open();
+    s->proto = &pico_proto_udp;
+
     fail_if(!s);
 
     /* Test with ERR */

--- a/test/unit/modunit_pico_dns_client.c
+++ b/test/unit/modunit_pico_dns_client.c
@@ -6,9 +6,11 @@
 #include "pico_ipv6.h"
 #include "pico_dns_client.h"
 #include "pico_tree.h"
+#include "pico_udp.h"
 #include "modules/pico_dns_client.c"
 #include "check.h"
 
+Suite *pico_suite(void);
 
 START_TEST(tc_pico_dns_client_callback)
 {
@@ -16,10 +18,10 @@ START_TEST(tc_pico_dns_client_callback)
     fail_if(!s);
 
     /* Test with ERR */
-    pico_dns_client_callback(s, PICO_SOCK_EV_ERR);
+    pico_dns_client_callback(PICO_SOCK_EV_ERR, s);
 
     /* Test with failing RD */
-    pico_dns_client_callback(s, PICO_SOCK_EV_RD);
+    pico_dns_client_callback(PICO_SOCK_EV_RD, s);
 
 }
 END_TEST

--- a/test/unit/modunit_pico_dns_common.c
+++ b/test/unit/modunit_pico_dns_common.c
@@ -9,6 +9,8 @@
 #include "modules/pico_dns_common.c"
 #include "check.h"
 
+Suite *pico_suite(void);
+
 START_TEST(tc_dns_rdata_cmp) /* MARK: dns_rdata_cmp */
 {
     uint8_t rdata1[10] = {
@@ -105,13 +107,14 @@ START_TEST(tc_dns_rdata_cmp) /* MARK: dns_rdata_cmp */
 END_TEST
 START_TEST(tc_dns_question_cmp) /* MARK: dns_question_cmp */
 {
-    printf("*********************** starting %s * \n", __func__);
     struct pico_dns_question *a = NULL, *b = NULL;
     const char *url1 = "host (2).local";
     const char *url3 = "host.local";
     const char *url2 = "192.168.2.1";
     uint16_t len = 0;
     int ret = 0;
+
+    printf("*********************** starting %s * \n", __func__);
 
     a = pico_dns_question_create(url1, &len, PICO_PROTO_IPV4, PICO_DNS_TYPE_A,
                                  PICO_DNS_CLASS_IN, 0);
@@ -140,14 +143,15 @@ START_TEST(tc_dns_question_cmp) /* MARK: dns_question_cmp */
 END_TEST
 START_TEST(tc_dns_qtree_insert) /* MARK: dns_qtree_insert*/
 {
-    printf("*********************** starting %s * \n", __func__);
-    char *url = "host.local";
-    char *url2 = "host (2).local";
-    char *url3 = "host (3).local";
+    const char *url = "host.local";
+    const char *url2 = "host (2).local";
+    const char *url3 = "host (3).local";
     struct pico_dns_question *a = NULL, *b = NULL, *c = NULL;
     uint16_t qlen = 0;
     PICO_DNS_QTREE_DECLARE(qtree);
     PICO_DNS_QTREE_DECLARE(qtree2);
+
+    printf("*********************** starting %s * \n", __func__);
 
     a = pico_dns_question_create(url, &qlen, PICO_PROTO_IPV4, PICO_DNS_TYPE_A,
                                  PICO_DNS_CLASS_IN, 0);
@@ -244,12 +248,10 @@ START_TEST(tc_dns_rtree_insert) /* MARK: dns_rtree_insert*/
     struct pico_dns_record *a = NULL;
     struct pico_dns_record *b = NULL, *c = NULL;
     const char *url1 = "foo.local";
-    const char *url3 = "a.local";
     struct pico_ip4 rdata = {
         0
     };
     uint16_t len = 0;
-    int ret = 0;
 
     printf("*********************** starting %s * \n", __func__);
 
@@ -305,8 +307,8 @@ START_TEST(tc_dns_record_cmp_name_type) /* MARK: dns_record_cmp_name_type */
     /* Try to compare records with equal rname but different type */
     ret = pico_dns_record_cmp_name_type((void *) a, (void *) b);
     fail_unless(ret > 0, "dns_record_cmp failed with same name, different types!\n");
-    pico_dns_record_delete(&a);
-    pico_dns_record_delete(&b);
+    pico_dns_record_delete((void **)&a);
+    pico_dns_record_delete((void **)&b);
 
     /* Create exactly the same test records */
     a  = pico_dns_record_create(url3, &rdata, 4, &len, PICO_DNS_TYPE_A,
@@ -319,8 +321,8 @@ START_TEST(tc_dns_record_cmp_name_type) /* MARK: dns_record_cmp_name_type */
     /* Try to compare records with different rname but equal type */
     ret = pico_dns_record_cmp_name_type((void *) a, (void *) b);
     fail_unless(!ret, "dns_record_cmp_name_type failed with same names, same types!\n");
-    pico_dns_record_delete(&a);
-    pico_dns_record_delete(&b);
+    pico_dns_record_delete((void **)&a);
+    pico_dns_record_delete((void **)&b);
 
     printf("*********************** ending %s * \n", __func__);
 }
@@ -344,6 +346,7 @@ START_TEST(tc_pico_dns_fill_packet_header) /* MARK: dns_fill_packet_header */
         0x00, 0x01,
         0x00, 0x01
     };
+    int i = 0;
 
     printf("*********************** starting %s * \n", __func__);
 
@@ -355,7 +358,6 @@ START_TEST(tc_pico_dns_fill_packet_header) /* MARK: dns_fill_packet_header */
     /* Create a query header */
     pico_dns_fill_packet_header(header, 1, 1, 1, 1);
 
-    int i;
     for (i = 0; i < 12; i++)
         printf("### %02x :: %02x\n", ((uint8_t*)header)[i], query_buf[i]);
     fail_unless(0 == memcmp((void *)header, (void *)query_buf, 12),
@@ -468,7 +470,7 @@ START_TEST(tc_pico_dns_fill_packet_question_section) /* MARK: dns_fill_packet_qu
         0x00u, 0x01u,
         0x00u, 0x01u
     };                                     /* 4 */
-    uint16_t len = 0, i = 0;
+    uint16_t len = 0;
 
     printf("*********************** starting %s * \n", __func__);
 
@@ -502,7 +504,7 @@ START_TEST(tc_pico_dns_fill_packet_question_section) /* MARK: dns_fill_packet_qu
 END_TEST
 START_TEST(tc_pico_dns_packet_compress_find_ptr) /* MARK: dns_packet_compress_find_ptr */
 {
-    uint8_t *data = (uint8_t *)"abcdef\5local\0abcdef\4test\5local";
+    uint8_t data[] = "abcdef\5local\0abcdef\4test\5local";
     uint8_t *name = (uint8_t *)(data + 24);
     uint16_t len = 31;
     uint8_t *ptr = NULL;
@@ -683,15 +685,16 @@ START_TEST(tc_pico_dns_question_create) /* MARK: dns_quesiton_create */
         0x00u
     };
     uint16_t len = 0;
+    struct pico_dns_question *a = NULL;
 
     printf("*********************** starting %s * \n", __func__);
 
     /* First, plain A record */
-    struct pico_dns_question *a = pico_dns_question_create(qurl, &len,
-                                                           PICO_PROTO_IPV4,
-                                                           PICO_DNS_TYPE_A,
-                                                           PICO_DNS_CLASS_IN,
-                                                           0);
+    a = pico_dns_question_create(qurl, &len,
+                                 PICO_PROTO_IPV4,
+                                 PICO_DNS_TYPE_A,
+                                 PICO_DNS_CLASS_IN,
+                                 0);
     fail_if(a == NULL, "dns_question_created returned NULL!\n");
     fail_unless(strcmp(a->qname, buf) == 0, "url not converted correctly!\n");
     fail_unless(short_be(a->qsuffix->qtype) == PICO_DNS_TYPE_A,
@@ -773,10 +776,10 @@ START_TEST(tc_pico_dns_query_create) /* MARK: dns_query_create */
 END_TEST
 START_TEST(tc_pico_dns_record_fill_suffix) /* MARK: dns_record_fill_suffix */
 {
+    struct pico_dns_record_suffix *suffix = NULL;
 
     printf("*********************** starting %s * \n", __func__);
 
-    struct pico_dns_record_suffix *suffix = NULL;
     pico_dns_record_fill_suffix(&suffix, PICO_DNS_TYPE_A, PICO_DNS_CLASS_IN,
                                 120, 4);
 
@@ -819,7 +822,7 @@ START_TEST(tc_pico_dns_record_copy_flat) /* MARK: dns_record_copy_flat */
                                     PICO_DNS_CLASS_IN, 120);
     fail_if(!record, "dns_record_create failed!\n");
 
-    *ptr = buf + 20;
+    ptr = buf + 20;
 
     /* Try to copy the record to a flat buffer */
     ret = pico_dns_record_copy_flat(record, &ptr);
@@ -829,7 +832,7 @@ START_TEST(tc_pico_dns_record_copy_flat) /* MARK: dns_record_copy_flat */
                 "dns_record_copy_flat failed!\n");
 
     /* FREE memory */
-    pico_dns_record_delete(&record);
+    pico_dns_record_delete((void **)&record);
     printf("*********************** ending %s * \n", __func__);
 }
 END_TEST
@@ -866,8 +869,8 @@ START_TEST(tc_pico_dns_record_copy) /* MARK: dns_record_copy */
                 "dns_record_copy failed copying rdata!\n");
 
     /* FREE memory */
-    pico_dns_record_delete(&a);
-    pico_dns_record_delete(&b);
+    pico_dns_record_delete((void **)&a);
+    pico_dns_record_delete((void **)&b);
     printf("*********************** ending %s * \n", __func__);
 }
 END_TEST
@@ -889,7 +892,7 @@ START_TEST(tc_pico_dns_record_delete) /* MARK: dns_record_delete */
     fail_if(!a, "dns_record_create failed!\n");
 
     /* Try to delete the created record */
-    ret = pico_dns_record_delete(&a);
+    ret = pico_dns_record_delete((void **)&a);
     fail_unless(ret == 0, "pico_dns_record_delete returned NULL!\n");
     fail_unless(a == NULL, "pico_dns_record_delete failed!\n");
     printf("*********************** ending %s * \n", __func__);
@@ -925,7 +928,7 @@ START_TEST(tc_pico_dns_record_create) /* MARK: dns_record_create */
 
     /* TODO: Test PTR records */
 
-    pico_dns_record_delete(&a);
+    pico_dns_record_delete((void **)&a);
     printf("*********************** ending %s * \n", __func__);
 }
 END_TEST
@@ -940,7 +943,6 @@ START_TEST(tc_pico_dns_answer_create) /* MARK: dns_answer_create */
         10, 10, 0, 1
     };
     uint16_t len = 0;
-    int ret = 0, i = 0;
     uint8_t buf[62] = {
         0x00u, 0x00u,
         0x85u, 0x00u,
@@ -1065,7 +1067,7 @@ START_TEST(tc_pico_dns_url_to_reverse_qname) /* MARK: dns_url_to_reverse_qname *
 {
     const char *url_ipv4 = "10.10.0.1";
     const char *url_ipv6 = "2001:0db8:0000:0000:0000:0000:0000:0000";
-    const char *qname = NULL;
+    char *qname = NULL;
     char cmp_buf1[24] = {
         0x01, '1',
         0x01, '0',
@@ -1124,7 +1126,7 @@ START_TEST(tc_pico_dns_qname_to_url) /* MARK: dns_qname_to_url */
         0x00
     };
     char qname3[14] = {
-        0x08, 'p', 'i', 'c', 'o', '\.', 't', 'c', 'p',
+        0x08, 'p', 'i', 'c', 'o', '.', 't', 'c', 'p',
         0x03, 'c', 'o', 'm',
         0x00
     };
@@ -1208,10 +1210,10 @@ START_TEST(tc_pico_dns_name_to_dns_notation) /* MARK: dns_name_to_dns_notation *
 
     printf("*********************** starting %s * \n", __func__);
 
-    ret = pico_dns_name_to_dns_notation(url1, strlen(url1));
+    ret = pico_dns_name_to_dns_notation(url1, (uint16_t)strlen(url1));
     fail_unless(ret == -1, "dns_name_to_dns_notation didn't check correct!\n");
 
-    ret = pico_dns_name_to_dns_notation(url2, strlen(url2));
+    ret = pico_dns_name_to_dns_notation(url2, (uint16_t)strlen(url2));
     fail_unless(ret == 0, "dns_name_to_dns_notation returned error!\n");
     fail_unless(strcmp(url2, qname1) == 0,
                 "dns_name_to_dns_notation failed! %s\n", url2);
@@ -1232,7 +1234,7 @@ START_TEST(tc_pico_dns_notation_to_name) /* MARK: dns_notation_to_name */
 
     printf("*********************** starting %s * \n", __func__);
 
-    ret = pico_dns_notation_to_name(qname1, strlen(qname1));
+    ret = pico_dns_notation_to_name(qname1, (uint16_t)strlen(qname1));
     fail_unless(ret == 0, "dns_notation_to_name returned error!\n");
     fail_unless(strcmp(url1, qname1) == 0,
                 "dns_notation_to_name failed! %s\n", qname1);
@@ -1242,7 +1244,7 @@ END_TEST
 START_TEST(tc_pico_dns_mirror_addr) /* MARK: dns_mirror_addr */
 {
     char url[12] = "192.168.0.1";
-    int8_t ret = 0;
+    int ret = 0;
 
     printf("*********************** starting %s * \n", __func__);
 
@@ -1317,6 +1319,7 @@ Suite *pico_suite(void)
     /* DNS packet section filling */
     TCase *TCase_pico_dns_fill_packet_header = tcase_create("Unit test for 'pico_dns_fill_packet_header'");
     TCase *TCase_pico_dns_fill_packet_rr_sections = tcase_create("Unit test for 'pico_dns_fill_packet_rr_sections'");
+    TCase *TCase_pico_dns_fill_packet_rr_section = tcase_create("Unit test for 'pico_dns_fill_packet_rr_section'");
     TCase *TCase_pico_dns_fill_packet_question_section = tcase_create("Unit test for 'pico_dns_fill_packet_question_sections'");
 
     /* DNS packet compression */
@@ -1363,6 +1366,7 @@ Suite *pico_suite(void)
     tcase_add_test(TCase_dns_rtree_insert, tc_dns_rtree_insert);
     tcase_add_test(TCase_dns_record_cmp_name_type, tc_dns_record_cmp_name_type);
     tcase_add_test(TCase_pico_dns_fill_packet_header, tc_pico_dns_fill_packet_header);
+    tcase_add_test(TCase_pico_dns_fill_packet_rr_section, tc_pico_dns_fill_packet_rr_section);
     tcase_add_test(TCase_pico_dns_fill_packet_rr_sections, tc_pico_dns_fill_packet_rr_sections);
     tcase_add_test(TCase_pico_dns_fill_packet_question_section, tc_pico_dns_fill_packet_question_section);
     tcase_add_test(TCase_pico_dns_packet_compress_find_ptr, tc_pico_dns_packet_compress_find_ptr);
@@ -1398,6 +1402,7 @@ Suite *pico_suite(void)
     suite_add_tcase(s, TCase_dns_rtree_insert);
     suite_add_tcase(s, TCase_dns_record_cmp_name_type);
     suite_add_tcase(s, TCase_pico_dns_fill_packet_header);
+    suite_add_tcase(s, TCase_pico_dns_fill_packet_rr_section);
     suite_add_tcase(s, TCase_pico_dns_fill_packet_rr_sections);
     suite_add_tcase(s, TCase_pico_dns_fill_packet_question_section);
     suite_add_tcase(s, TCase_pico_dns_packet_compress_find_ptr);

--- a/test/unit/modunit_pico_ethernet.c
+++ b/test/unit/modunit_pico_ethernet.c
@@ -9,7 +9,6 @@
 #include "modules/pico_ethernet.c"
 #include "check.h"
 
-
 #define STARTING()                                                             \
             printf("*********************** STARTING %s ***\n", __func__);     \
             fflush(stdout)
@@ -33,6 +32,9 @@
 #define DBG(s, ...)                                                            \
             printf(s, ##__VA_ARGS__);                                          \
             fflush(stdout)
+
+Suite *pico_suite(void);
+
 START_TEST(tc_destination_is_bcast)
 {
     /* test this: static int destination_is_bcast(struct pico_frame *f) */
@@ -195,7 +197,7 @@ START_TEST(tc_pico_ipv6_ethernet_receive)
     TRYING("With correct network type\n");
     ret = pico_ipv6_ethernet_receive(f);
     CHECKING(count);
-    fail_unless(ret == f->buffer_len, "Was correct frame, should've returned success\n");
+    fail_unless(ret == (int32_t)f->buffer_len, "Was correct frame, should've returned success\n");
     SUCCESS();
     CHECKING(count);
     fail_unless(pico_proto_ipv6.q_in->size == f->buffer_len, "Frame not enqueued\n");
@@ -207,8 +209,6 @@ END_TEST
 START_TEST(tc_pico_eth_receive)
 {
     struct pico_frame *f = NULL;
-    struct pico_ipv6_hdr *h = NULL;
-    struct pico_ipv4_hdr *h4 = NULL;
     struct pico_eth_hdr *eth = NULL;
     int ret = 0, count = 0;
 
@@ -217,7 +217,6 @@ START_TEST(tc_pico_eth_receive)
     f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr) + sizeof(struct pico_eth_hdr));
     f->datalink_hdr = f->buffer;
     f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-    h = (struct pico_ipv6_hdr *)f->net_hdr;
     eth = (struct pico_eth_hdr *)f->datalink_hdr;
     ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
 
@@ -233,7 +232,6 @@ START_TEST(tc_pico_eth_receive)
     f = pico_frame_alloc(sizeof(struct pico_ipv6_hdr) + sizeof(struct pico_eth_hdr));
     f->datalink_hdr = f->buffer;
     f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-    h = (struct pico_ipv6_hdr *)f->net_hdr;
     eth = (struct pico_eth_hdr *)f->datalink_hdr;
     ((uint8_t *)(f->net_hdr))[0] = 0x60; /* Ipv6 */
 
@@ -242,7 +240,7 @@ START_TEST(tc_pico_eth_receive)
     TRYING("With correct network type\n");
     ret = pico_eth_receive(f);
     CHECKING(count);
-    fail_unless(ret == f->buffer_len, "Was correct frame, should've returned success\n");
+    fail_unless(ret == (int32_t)f->buffer_len, "Was correct frame, should've returned success\n");
     SUCCESS();
     CHECKING(count);
     fail_unless(pico_proto_ipv6.q_in->size == f->buffer_len, "Frame not enqueued\n");
@@ -253,7 +251,6 @@ START_TEST(tc_pico_eth_receive)
     f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr) + sizeof(struct pico_eth_hdr));
     f->datalink_hdr = f->buffer;
     f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-    h4 = (struct pico_ipv4_hdr *)f->net_hdr;
     eth = (struct pico_eth_hdr *)f->datalink_hdr;
     ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
 
@@ -266,7 +263,6 @@ START_TEST(tc_pico_eth_receive)
     f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr) + sizeof(struct pico_eth_hdr));
     f->datalink_hdr = f->buffer;
     f->net_hdr = f->datalink_hdr + sizeof(struct pico_eth_hdr);
-    h4 = (struct pico_ipv4_hdr *)f->net_hdr;
     eth = (struct pico_eth_hdr *)f->datalink_hdr;
     ((uint8_t *)(f->net_hdr))[0] = 0x40; /* Ipv4 */
     eth->proto = PICO_IDETH_IPV4;

--- a/test/unit/modunit_pico_fragments.c
+++ b/test/unit/modunit_pico_fragments.c
@@ -986,7 +986,7 @@ START_TEST(tc_pico_ipv6_process_frag)
     /* NULL frame provided */
     ipv6_cur_frag_id = 0;
     timer_add_called = 0;
-    pico_ipv4_process_frag(hdr, a, TESTPROTO);
+    pico_ipv6_process_frag(hdr, a, TESTPROTO);
     fail_if(ipv6_cur_frag_id != 0);
     fail_if(timer_add_called != 0);
 

--- a/test/unit/modunit_pico_frame.c
+++ b/test/unit/modunit_pico_frame.c
@@ -72,6 +72,7 @@ START_TEST(tc_pico_frame_grow_head)
 
     /* Try to grow head */
     ret = pico_frame_grow_head(f, 6);
+    fail_if(ret != 0);
     fail_unless(0 == memcmp(f->buffer, buf, f->buffer_len));
     fail_unless(3 == f->net_hdr - f->buffer);
 

--- a/test/unit/modunit_pico_frame.c
+++ b/test/unit/modunit_pico_frame.c
@@ -6,8 +6,9 @@
 
 volatile pico_err_t pico_err;
 
-
 #define FRAME_SIZE 1000
+
+Suite *pico_suite(void);
 
 START_TEST(tc_pico_frame_alloc_discard)
 {

--- a/test/unit/modunit_pico_hotplug_detection.c
+++ b/test/unit/modunit_pico_hotplug_detection.c
@@ -5,11 +5,20 @@
 #include "check.h"
 #include "pico_dev_null.c"
 
+Suite *pico_suite(void);
+void cb_one(struct pico_device *dev, int event);
+void cb_two(struct pico_device *dev, int event);
+int link_state_a(struct pico_device *self);
+int link_state_b(struct pico_device *self);
+
 /* stubs for timer */
 static int8_t timer_active = 0;
 void (*timer_cb_function)(pico_time, void *);
 uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void *arg)
 {
+    IGNORE_PARAMETER(expire);
+    IGNORE_PARAMETER(arg);
+
     timer_active++;
     timer_cb_function = timer;
 
@@ -27,6 +36,8 @@ uint32_t cb_one_cntr = 0;
 int cb_one_last_event = 0;
 void cb_one(struct pico_device *dev, int event)
 {
+    IGNORE_PARAMETER(dev);
+
     cb_one_cntr++;
     cb_one_last_event = event;
 }
@@ -34,6 +45,8 @@ uint32_t cb_two_cntr = 0;
 int cb_two_last_event = 0;
 void cb_two(struct pico_device *dev, int event)
 {
+    IGNORE_PARAMETER(dev);
+
     cb_two_cntr++;
     cb_two_last_event = event;
 }
@@ -42,12 +55,14 @@ void cb_two(struct pico_device *dev, int event)
 int state_a = 0;
 int link_state_a(struct pico_device *self)
 {
+    IGNORE_PARAMETER(self);
     return state_a;
 }
 
 int state_b = 0;
 int link_state_b(struct pico_device *self)
 {
+    IGNORE_PARAMETER(self);
     return state_b;
 }
 
@@ -101,6 +116,7 @@ START_TEST(tc_pico_hotplug_callbacks)
 {
     /* create some devices */
     struct pico_device *dev_a, *dev_b;
+
     dev_a = pico_null_create("dummy1");
     dev_b = pico_null_create("dummy2");
 

--- a/test/unit/modunit_pico_igmp.c
+++ b/test/unit/modunit_pico_igmp.c
@@ -8,7 +8,9 @@
 #include "modules/pico_igmp.c"
 #include "check.h"
 #include "pico_dev_null.c"
+
 Suite *pico_suite(void);
+void mock_callback(struct igmp_timer *t);
 
 static uint32_t timers_added = 0;
 uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void *arg)
@@ -18,10 +20,10 @@ uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void
     IGNORE_PARAMETER(arg);
     return ++timers_added;
 }
-int mock_callback(struct igmp_timer *t)
+
+void mock_callback(struct igmp_timer *t)
 {
     IGNORE_PARAMETER(t);
-    return 0;
 }
 static int mcast_filter_cmp(void *ka, void *kb)
 {
@@ -49,7 +51,7 @@ static PICO_TREE_DECLARE(_MCASTFilter, mcast_filter_cmp);
 START_TEST(tc_pico_igmp_report_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 zero = {{0}};
+    struct pico_ip4 zero = {0};
     t->mcast_link = zero;
     t->mcast_group = zero;
     /* void function, just check for side effects */
@@ -70,11 +72,8 @@ END_TEST
 START_TEST(tc_pico_igmp_state_change)
 {
     struct pico_ip4 mcast_link, mcast_group;
-    struct mcast_parameters p;
     pico_string_to_ipv4("192.168.1.1", &mcast_link.addr);
     pico_string_to_ipv4("224.7.7.7", &mcast_group.addr);
-    p.mcast_link.ip4 = mcast_link;
-    p.mcast_group.ip4 = mcast_group;
     fail_if(pico_igmp_state_change(&mcast_link, &mcast_group, 0, NULL, 99) != -1);
     fail_if(pico_igmp_state_change(&mcast_link, &mcast_group, 0, NULL, PICO_IGMP_STATE_CREATE) != 0);
 }
@@ -88,30 +87,30 @@ START_TEST(tc_pico_igmp_timer_expired)
     pico_string_to_ipv4("192.168.1.1", &t->mcast_link.addr);
     pico_string_to_ipv4("244.7.7.7", &t->mcast_group.addr);
     /* void function, just check for side effects */
-    pico_igmp_timer_expired(NULL, (void *)t);
+    pico_igmp_timer_expired(0, (void *)t);
     pico_tree_insert(&IGMPTimers, t);
     s = PICO_ZALLOC(sizeof(struct igmp_timer));
     memcpy(s,t,sizeof(struct igmp_timer)); // t will be freed next test
-    pico_igmp_timer_expired(NULL, (void *)t); /* t is freed here */
+    pico_igmp_timer_expired(0, (void *)t); /* t is freed here */
     s->stopped++;
     s->start = PICO_TIME_MS()*2;
     s->type++;
     pico_tree_insert(&IGMPTimers, s);
     t = PICO_ZALLOC(sizeof(struct igmp_timer));
     memcpy(t,s,sizeof(struct igmp_timer)); // s will be freed next test
-    pico_igmp_timer_expired(NULL, (void *)s); /* s is freed here */
+    pico_igmp_timer_expired(0, (void *)s); /* s is freed here */
     t->callback = mock_callback;
-    pico_igmp_timer_expired(NULL, (void *)t);
+    pico_igmp_timer_expired(0, (void *)t);
 }
 END_TEST
 START_TEST(tc_pico_igmp_v2querier_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 addr = {{0}};
+    struct pico_ip4 addr = {0};
     struct pico_device *dev = pico_null_create("dummy2");
     struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_frame));
     t->f = f;
-    pico_string_to_ipv4("192.168.1.1", addr.addr);
+    pico_string_to_ipv4("192.168.1.1", &(addr.addr));
     /* void function, just check for side effects */
     /* No link */
     pico_igmp_v2querier_expired(t);
@@ -131,7 +130,8 @@ START_TEST(tc_pico_igmp_process_in)
     struct mcast_parameters *p;
     struct pico_device *dev = pico_null_create("dummy3");
     struct pico_ipv4_link *link;
-    int i, j, _i, _j, result;
+    uint8_t i, j, _i, _j;
+    int result;
     struct pico_mcast_group g;
     /* Building example frame */
     p = PICO_ZALLOC(sizeof(struct mcast_parameters));
@@ -217,16 +217,16 @@ START_TEST(tc_pico_igmp_compatibility_mode)
     pico_ipv4_link_add(dev, addr, addr);
     f->dev = dev;
     /* Igmpv3 query */
-    hdr->len = short_be(12 + ihl);
+    hdr->len = short_be((uint16_t)(12 + ihl));
     fail_if(pico_igmp_compatibility_mode(f) != 0);
     /* Igmpv2 query */
-    hdr->len = short_be(8 + ihl);
+    hdr->len = short_be((uint16_t)(8 + ihl));
     query->max_resp_time = 0;
     fail_if(pico_igmp_compatibility_mode(f) == 0);
     query->max_resp_time = 1;
     fail_if(pico_igmp_compatibility_mode(f) != 0);
     /* Invalid Query */
-    hdr->len = short_be(9 + ihl);
+    hdr->len = short_be((uint16_t)(9 + ihl));
     fail_if(pico_igmp_compatibility_mode(f) == 0);
 }
 END_TEST
@@ -235,15 +235,14 @@ START_TEST(tc_pico_igmp_analyse_packet)
     struct pico_frame *f;
     struct pico_device *dev = pico_null_create("dummy0");
     struct pico_ip4 addr;
-    struct pico_ipv4_hdr *ip4;
     struct igmp_message *igmp;
+
     f = pico_proto_ipv4.alloc(&pico_proto_ipv4, sizeof(struct igmp_message));
     pico_string_to_ipv4("192.168.1.1", &addr.addr);
     /* No link */
     fail_if(pico_igmp_analyse_packet(f) != NULL);
     pico_ipv4_link_add(dev, addr, addr);
     f->dev = dev;
-    ip4 = f->net_hdr;
 
     igmp = (struct igmp_message *) (f->transport_hdr);
     igmp->type = 0;
@@ -271,6 +270,7 @@ START_TEST(tc_srst)
     struct mcast_parameters p;
     struct pico_device *dev = pico_null_create("dummy0");
     struct pico_ipv4_link *link;
+
     pico_string_to_ipv4("192.168.1.1", &p.mcast_link.ip4.addr);
     /* no link */
     fail_if(srst(&p) != -1);
@@ -286,8 +286,8 @@ END_TEST
 START_TEST(tc_stcl)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_device *dev = pico_null_create("dummy0");
     struct mcast_parameters p;
+
     pico_string_to_ipv4("192.168.1.10", &t->mcast_link.addr);
     pico_string_to_ipv4("244.7.7.7", &t->mcast_group.addr);
     p.mcast_link.ip4 = t->mcast_link;

--- a/test/unit/modunit_pico_igmp.c
+++ b/test/unit/modunit_pico_igmp.c
@@ -51,7 +51,8 @@ static PICO_TREE_DECLARE(_MCASTFilter, mcast_filter_cmp);
 START_TEST(tc_pico_igmp_report_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 zero = {0};
+    struct pico_ip4 zero = {};
+
     t->mcast_link = zero;
     t->mcast_group = zero;
     /* void function, just check for side effects */
@@ -106,7 +107,7 @@ END_TEST
 START_TEST(tc_pico_igmp_v2querier_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 addr = {0};
+    struct pico_ip4 addr = {};
     struct pico_device *dev = pico_null_create("dummy2");
     struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_frame));
     t->f = f;

--- a/test/unit/modunit_pico_igmp.c
+++ b/test/unit/modunit_pico_igmp.c
@@ -51,8 +51,7 @@ static PICO_TREE_DECLARE(_MCASTFilter, mcast_filter_cmp);
 START_TEST(tc_pico_igmp_report_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 zero = {};
-
+    struct pico_ip4 zero = {0};
     t->mcast_link = zero;
     t->mcast_group = zero;
     /* void function, just check for side effects */
@@ -107,7 +106,7 @@ END_TEST
 START_TEST(tc_pico_igmp_v2querier_expired)
 {
     struct igmp_timer *t = PICO_ZALLOC(sizeof(struct igmp_timer));
-    struct pico_ip4 addr = {};
+    struct pico_ip4 addr = {0};
     struct pico_device *dev = pico_null_create("dummy2");
     struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_frame));
     t->f = f;

--- a/test/unit/modunit_pico_mdns.c
+++ b/test/unit/modunit_pico_mdns.c
@@ -57,7 +57,7 @@ int mdns_init() /* MARK: Initialise mDNS module */
         {&LEAF, pico_dns_question_cmp}, \
         {&LEAF, pico_mdns_record_cmp}, \
         {&LEAF, pico_mdns_record_cmp}, \
-        0, 0, 0, 0, NULL, NULL, NULL \
+        0, 0, 0, 0, 0, NULL, NULL \
     }
 
 START_TEST(tc_mdns_init) /* MARK: mdns_init */
@@ -375,10 +375,10 @@ START_TEST(tc_mdns_cookie_delete) /* MARK: mdns_cookie_delete */
 
     printf("*********************** starting %s * \n", __func__);
 
-    fail_unless(pico_mdns_cookie_delete(&a),
+    fail_unless(pico_mdns_cookie_delete((void **)&a),
                 "mdns_cookie_delete failed checking params!\n");
     a = pico_mdns_cookie_create(qtree, antree, artree, 0, 0, NULL, NULL);
-    fail_unless(!pico_mdns_cookie_delete(&a),
+    fail_unless(!pico_mdns_cookie_delete((void **)&a),
                 "mdns_cookie_delete failed!\n");
 
     fail_unless(pico_mdns_cookie_delete(NULL),
@@ -399,7 +399,7 @@ START_TEST(tc_mdns_cookie_create) /* MARK: mdns_cookie_create */
     a = pico_mdns_cookie_create(qtree, antree, artree, 0, 0, NULL, NULL);
     fail_if(!a, "mdns_cookie_create failed!\n");
 
-    pico_mdns_cookie_delete(&a);
+    pico_mdns_cookie_delete((void **)&a);
 
     printf("*********************** ending %s * \n", __func__);
 }
@@ -475,8 +475,8 @@ START_TEST(tc_mdns_cookie_tree_find_query_cookie) /* MARK: mdns_ctree_find_cooki
 
     pico_tree_delete(&Cookies, a);
     pico_tree_delete(&Cookies, b);
-    pico_mdns_cookie_delete(&a);
-    pico_mdns_cookie_delete(&b);
+    pico_mdns_cookie_delete((void **)&a);
+    pico_mdns_cookie_delete((void **)&b);
 
     printf("*********************** ending %s * \n", __func__);
 }
@@ -1448,7 +1448,7 @@ START_TEST(tc_mdns_cache_add_record) /* MARK: mdns_cache_add_record */
     fail_unless(0 == ret,
                 "mdns_cache_add_record returned error!\n");
     found = pico_tree_findKey(&Cache, record);
-    fail_unless((int)found, "mdns_cache_add_record failed!\n");
+    fail_if(found == NULL, "mdns_cache_add_record failed!\n");
     ret = pico_mdns_cache_add_record(record);
     fail_unless(0 == ret,
                 "mdns_cache_add_record returned error!\n");
@@ -1749,10 +1749,11 @@ START_TEST(tc_mdns_send_query_packet) /* MARK: send_query_packet */
     struct pico_mdns_cookie cookie;
     PICO_DNS_QTREE_DECLARE(qtree);
     PICO_MDNS_COOKIE_DECLARE(a);
+
     struct pico_dns_question *question1 = NULL;
     struct pico_dns_question *question2 = NULL;
     char url1[] = "foo.local";
-    int len;
+    uint16_t len;
     printf("*********************** starting %s * \n", __func__);
 
     /* Create some questions */
@@ -1818,7 +1819,7 @@ START_TEST(tc_mdns_getrecord) /* MARK: getrecord */
     fail_unless(0 == ret,
                 "mdns_cache_add_record returned error!\n");
     found = pico_tree_findKey(&Cache, record);
-    fail_unless((int)found, "mdns_cache_add_record failed!\n");
+    fail_if(found == NULL, "mdns_cache_add_record failed!\n");
 #endif
 
 #if PICO_MDNS_ALLOW_CACHING == 1

--- a/test/unit/modunit_pico_mld.c
+++ b/test/unit/modunit_pico_mld.c
@@ -119,7 +119,7 @@ END_TEST
 START_TEST(tc_pico_mld_report_expired)
 {
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
-    struct pico_ip6 zero = {};
+    struct pico_ip6 zero = {0};
 
     t->mcast_link = zero;
     t->mcast_group = zero;

--- a/test/unit/modunit_pico_mld.c
+++ b/test/unit/modunit_pico_mld.c
@@ -8,7 +8,9 @@
 #include "modules/pico_mld.c"
 #include "check.h"
 #include "pico_dev_null.c"
+
 Suite *pico_suite(void);
+void mock_callback(struct mld_timer *t);
 
 static uint32_t timers_added = 0;
 uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void *arg)
@@ -18,10 +20,9 @@ uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void
     IGNORE_PARAMETER(arg);
     return ++timers_added;
 }
-int mock_callback(struct mld_timer *t)
+void mock_callback(struct mld_timer *t)
 {
     IGNORE_PARAMETER(t);
-    return 0;
 }
 static int mcast_filter_cmp_ipv6(void *ka, void *kb)
 {
@@ -118,16 +119,12 @@ END_TEST
 START_TEST(tc_pico_mld_report_expired)
 {
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
-    struct pico_ip6 zero = {{0}};
-    struct mcast_parameters p;
+    struct pico_ip6 zero = {0};
+
     t->mcast_link = zero;
     t->mcast_group = zero;
-    p.mcast_link.ip6 = zero;
-    p.mcast_group.ip6 = zero;
     /* void function, just check for side effects */
     pico_mld_report_expired(t);
-    /* pico_tree_insert(&MLDParameters, &p); */
-    /* pico_mld_report_expired(&t); */
 }
 END_TEST
 START_TEST(tc_pico_mld_delete_parameter)
@@ -182,20 +179,20 @@ START_TEST(tc_pico_mld_timer_expired)
     pico_string_to_ipv6("AAAA::112", t->mcast_link.addr);
     pico_string_to_ipv6("AAAA::112", t->mcast_group.addr);
     /* void function, just check for side effects */
-    pico_mld_timer_expired(NULL, (void *)t);
+    pico_mld_timer_expired(0, (void *)t);
     pico_tree_insert(&MLDTimers, t);
     s = PICO_ZALLOC(sizeof(struct mld_timer));
     memcpy(s, t, sizeof(struct mld_timer)); /* t will be freed next test */
-    pico_mld_timer_expired(NULL, (void *)t); /* will be freed */
+    pico_mld_timer_expired(0, (void *)t); /* will be freed */
     s->stopped++;
     s->start = PICO_TIME_MS() * 2;
     s->type++;
     pico_tree_insert(&MLDTimers, s);
     t = PICO_ZALLOC(sizeof(struct mld_timer));
     memcpy(t, s, sizeof(struct mld_timer)); /* s will be freed next test */
-    pico_mld_timer_expired(NULL, (void *)s); /* s will be freed */
+    pico_mld_timer_expired(0, (void *)s); /* s will be freed */
     t->mld_callback = mock_callback;
-    pico_mld_timer_expired(NULL, (void *)t); /* t will be freed */
+    pico_mld_timer_expired(0, (void *)t); /* t will be freed */
 }
 END_TEST
 START_TEST(tc_pico_mld_send_done)
@@ -209,8 +206,6 @@ START_TEST(tc_mld_stsdifs)
     struct mcast_parameters *p;
     struct pico_device *dev = pico_null_create("dummy3");
     struct pico_ipv6_link *link;
-    struct pico_mcast_group g;
-    struct mldv2_report *report;
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
     /* Building example frame */
     p = PICO_ZALLOC(sizeof(struct mcast_parameters));
@@ -235,10 +230,6 @@ END_TEST
 START_TEST(tc_mld_srsf)
 {
     struct mcast_parameters *p;
-    struct pico_device *dev = pico_null_create("dummy3");
-    struct pico_ipv6_link *link;
-    struct pico_mcast_group g;
-    struct mldv2_report *report;
     /* Building example frame */
 
     p = PICO_ZALLOC(sizeof(struct mcast_parameters));
@@ -254,8 +245,6 @@ START_TEST(tc_mld_srst)
     struct pico_device *dev = pico_null_create("dummy3");
     struct pico_ipv6_link *link;
     struct pico_mcast_group g;
-    struct mldv2_report *report;
-    struct mld_timer t;
     /* Building example frame */
 
     p = PICO_ZALLOC(sizeof(struct mcast_parameters));
@@ -287,10 +276,6 @@ START_TEST(tc_mld_mrsrrt)
     struct mcast_parameters *p;
     struct pico_device *dev = pico_null_create("dummy3");
     struct pico_ipv6_link *link;
-    struct pico_tree *filter = PICO_ZALLOC(sizeof(struct pico_tree));
-    int i, j, _i, _j, result;
-    struct pico_mcast_group g;
-    struct mldv2_report *report;
     /* Building example frame */
     p = PICO_ZALLOC(sizeof(struct mcast_parameters));
     pico_string_to_ipv6("AAAA::115", p->mcast_link.ip6.addr);
@@ -312,8 +297,8 @@ START_TEST(tc_pico_mld_process_in)
     struct mcast_parameters *p;
     struct pico_device *dev = pico_null_create("dummy3");
     struct pico_ipv6_link *link;
-    struct pico_tree *filter = PICO_ZALLOC(sizeof(struct pico_tree));
-    int i, j, _i, _j, result;
+    uint8_t i, j, _i, _j;
+    int result = 0;
     struct pico_mcast_group g;
     struct mldv2_report *report;
     /* Building example frame */
@@ -358,7 +343,7 @@ START_TEST(tc_pico_mld_process_in)
                     p->state = i;
                     p->event = j;
                     if(result != -1 && p->f) { /* in some combinations, no frame is created */
-                        report = p->f->transport_hdr + MLD_ROUTER_ALERT_LEN;
+                        report = (struct mldv2_report *)(p->f->transport_hdr + MLD_ROUTER_ALERT_LEN);
                         report->crc = short_be(pico_icmp6_checksum(p->f));
                         fail_if(pico_mld_process_in(p->f) != 0);
                     }
@@ -373,7 +358,6 @@ END_TEST
 START_TEST(tc_mld_rtimrtct)
 {
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
-    struct pico_device *dev = pico_null_create("dummy0");
     struct mcast_parameters p;
     pico_string_to_ipv6("AAAA::102", t->mcast_link.addr);
     pico_string_to_ipv6("AAAA::102", t->mcast_group.addr);
@@ -390,7 +374,6 @@ END_TEST
 START_TEST(tc_mld_stcl)
 {
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
-    struct pico_device *dev = pico_null_create("dummy0");
     struct mcast_parameters p;
     pico_string_to_ipv6("AAAA::103", t->mcast_link.addr);
     pico_string_to_ipv6("AAAA::103", t->mcast_group.addr);
@@ -406,7 +389,7 @@ END_TEST
 START_TEST(tc_pico_mld_compatibility_mode)
 {
     struct pico_frame *f;
-    struct pico_device *dev = pico_null_create("ummy1");
+    struct pico_device *dev = pico_null_create("dummy1");
     struct pico_ip6 addr;
 
     f = pico_proto_ipv6.alloc(&pico_proto_ipv6, sizeof(struct mldv2_report) + MLD_ROUTER_ALERT_LEN + sizeof(struct mldv2_group_record) + (0 * sizeof(struct pico_ip6)));
@@ -425,7 +408,7 @@ START_TEST(tc_pico_mld_compatibility_mode)
     f->buffer_len = 25 + PICO_SIZE_IP6HDR + MLD_ROUTER_ALERT_LEN;
     fail_if(pico_mld_compatibility_mode(f) == 0);
     /* MLDv2 query + timer amready running */
-    f->dev->eth = dev;
+    f->dev = dev;
     f->buffer_len = 28 + PICO_SIZE_IP6HDR + MLD_ROUTER_ALERT_LEN + PICO_SIZE_ETHHDR;
     fail_if(pico_mld_compatibility_mode(f) != -1);
 }
@@ -450,7 +433,7 @@ START_TEST(tc_pico_mld_state_change)
 
     fail_if(pico_mld_state_change(NULL, &mcast_group, 0, NULL, PICO_MLD_STATE_CREATE) != -1);
     /* All host group */
-    pico_string_to_ipv6("FF01:0:0:0:0:0:0:1", &mcast_group.addr);
+    pico_string_to_ipv6("FF01:0:0:0:0:0:0:1", mcast_group.addr);
     fail_if(pico_mld_state_change(&mcast_link, &mcast_group, 0, NULL, PICO_MLD_STATE_CREATE) != 0);
     pico_string_to_ipv6("AAAA::107", mcast_group.addr);
     fail_if(pico_mld_state_change(&mcast_link, &mcast_group, 0, NULL, 99) != -1);
@@ -476,12 +459,12 @@ START_TEST(tc_pico_mld_analyse_packet)
     fail_if(pico_mld_analyse_packet(f) != NULL);
     pico_ipv6_link_add(dev, addr, addr);
     f->dev = dev;
-    ip6 = f->net_hdr;
-    ip6->hop == 99;
+    ip6 = (struct pico_ipv6_hdr *) f->net_hdr;
+    ip6->hop = 99;
     /* Incorrect hop */
     fail_if(pico_mld_analyse_packet(f) != NULL);
     ip6->hop = 1;
-    hbh = f->transport_hdr;
+    hbh = (struct pico_ipv6_hbhoption *) f->transport_hdr;
     pico_mld_fill_hopbyhop(hbh);
     hbh->type = 99;
     /* incorrect hop by hop */

--- a/test/unit/modunit_pico_mld.c
+++ b/test/unit/modunit_pico_mld.c
@@ -119,7 +119,7 @@ END_TEST
 START_TEST(tc_pico_mld_report_expired)
 {
     struct mld_timer *t = PICO_ZALLOC(sizeof(struct mld_timer));
-    struct pico_ip6 zero = {0};
+    struct pico_ip6 zero = {};
 
     t->mcast_link = zero;
     t->mcast_group = zero;

--- a/test/unit/modunit_pico_protocol.c
+++ b/test/unit/modunit_pico_protocol.c
@@ -3,6 +3,8 @@
 #include "stack/pico_protocol.c"
 #include "check.h"
 
+Suite *pico_suite(void);
+
 volatile pico_err_t pico_err = 0;
 
 static int protocol_passby = 0;
@@ -157,10 +159,14 @@ START_TEST(tc_pico_protocol_generic_loop)
     struct pico_proto_rr rr = {
         0
     };
-    int ret;
+    int ret = 0;
+
     rr.node_in = &NODE_IN;
     rr.node_out = &NODE_OUT;
     ret = pico_protocol_generic_loop(&rr, 0, PICO_LOOP_DIR_IN);
+
+    fail_if(ret != 0);
+
     pico_protocols_loop(0);
 }
 END_TEST

--- a/test/unit/modunit_pico_stack.c
+++ b/test/unit/modunit_pico_stack.c
@@ -21,6 +21,7 @@
 
 Suite *pico_suite(void);
 void fake_timer(pico_time __attribute__((unused)) now, void __attribute__((unused)) *n);
+
 START_TEST(tc_pico_ll_receive)
 {
     /* TODO: test this: static int32_t pico_ll_receive(struct pico_frame *f) */
@@ -85,7 +86,7 @@ START_TEST(tc_stack_generic)
 #ifdef PICO_FAULTY
     printf("Testing with faulty memory in pico_timer_add (1)\n");
     pico_set_mm_failure(1);
-    fail_if(pico_timer_add(0, fake_timer, NULL) != NULL);
+    fail_if(pico_timer_add(0, fake_timer, NULL) != 0);
 #endif
 
 

--- a/test/unit/modunit_pico_tftp.c
+++ b/test/unit/modunit_pico_tftp.c
@@ -292,8 +292,8 @@ END_TEST
 START_TEST(tc_tftp_socket_open)
 {
     /* TODO: test this: static int tftp_socket_open(uint16_t family, union pico_address *a, uint16_t port) */
-    fail_if(tftp_socket_open((uint16_t)-1, 21) != NULL);
-    fail_if(tftp_socket_open((uint16_t)-1, (uint16_t)-21) != NULL);
+    fail_if(tftp_socket_open(0xFFFF, 21) != NULL);
+    fail_if(tftp_socket_open(0xFFFF, 0xFFFF) != NULL);
 }
 END_TEST
 

--- a/test/unit/modunit_pico_tftp.c
+++ b/test/unit/modunit_pico_tftp.c
@@ -292,6 +292,8 @@ END_TEST
 START_TEST(tc_tftp_socket_open)
 {
     /* TODO: test this: static int tftp_socket_open(uint16_t family, union pico_address *a, uint16_t port) */
+    fail_if(tftp_socket_open((uint16_t)-1, 21) != NULL);
+    fail_if(tftp_socket_open((uint16_t)-1, (uint16_t)-21) != NULL);
 }
 END_TEST
 

--- a/test/unit/modunit_pico_tftp.c
+++ b/test/unit/modunit_pico_tftp.c
@@ -292,8 +292,6 @@ END_TEST
 START_TEST(tc_tftp_socket_open)
 {
     /* TODO: test this: static int tftp_socket_open(uint16_t family, union pico_address *a, uint16_t port) */
-    fail_if(tftp_socket_open((uint16_t)-1, 21) != NULL);
-    fail_if(tftp_socket_open((uint16_t)-1, (uint16_t)-21) != NULL);
 }
 END_TEST
 

--- a/test/unit/modunit_pico_tftp.c
+++ b/test/unit/modunit_pico_tftp.c
@@ -13,7 +13,7 @@ static int called_pico_socket_close = 0;
 static uint16_t expected_opcode = 0;
 static int called_user_cb = 0;
 static int called_sendto = 0;
-static int called_pico_timer_add = 0;
+static uint32_t called_pico_timer_add = 0;
 static int called_pico_timer_cancel = 0;
 static struct pico_socket example_socket;
 static struct pico_tftp_session example_session;
@@ -53,6 +53,7 @@ uint32_t pico_timer_add(pico_time expire, void (*timer)(pico_time, void *), void
     (void)expire;
     (void)timer;
     (void)arg;
+
     return ++called_pico_timer_add;
 }
 
@@ -291,8 +292,8 @@ END_TEST
 START_TEST(tc_tftp_socket_open)
 {
     /* TODO: test this: static int tftp_socket_open(uint16_t family, union pico_address *a, uint16_t port) */
-    fail_if(tftp_socket_open(-1, 21) != NULL);
-    fail_if(tftp_socket_open(-1, -21) != NULL);
+    fail_if(tftp_socket_open((uint16_t)-1, 21) != NULL);
+    fail_if(tftp_socket_open((uint16_t)-1, (uint16_t)-21) != NULL);
 }
 END_TEST
 

--- a/test/unit/modunit_seq.c
+++ b/test/unit/modunit_seq.c
@@ -1,5 +1,8 @@
 #include "pico_tcp.c"
 #include <check.h>
+
+Suite *pico_suite(void);
+
 START_TEST(tc_seq_compare)
 {
     uint32_t big_a = 0xFFFFFF0alu;

--- a/test/unit/unit_arp.c
+++ b/test/unit/unit_arp.c
@@ -81,7 +81,7 @@ START_TEST(tc_pico_arp_queue)
     struct pico_frame *f = pico_frame_alloc(sizeof(struct pico_ipv4_hdr));
     struct pico_ipv4_hdr *h = (struct pico_ipv4_hdr *) f->buffer;
     fail_if(!f);
-    f->net_hdr = h;
+    f->net_hdr = (uint8_t *)h;
     h->dst.addr = addr.addr;
 
     for (i = 0; i < PICO_ND_MAX_FRAMES_QUEUED; i++) {

--- a/test/unit/unit_dhcp.c
+++ b/test/unit/unit_dhcp.c
@@ -1,6 +1,9 @@
 
 static struct pico_dhcp_client_cookie*dhcp_client_ptr;
 
+void callback_dhcpclient(void*cli, int code);
+int generate_dhcp_msg(uint8_t *buf, uint32_t *len, uint8_t type);
+
 void callback_dhcpclient(void*cli, int code)
 {
     struct pico_ip4 gateway;
@@ -42,7 +45,7 @@ int generate_dhcp_msg(uint8_t *buf, uint32_t *len, uint8_t type)
     }else if(type == DHCP_MSG_TYPE_OFFER) {
         return 1;
     }else if(type == DHCP_MSG_TYPE_REQUEST) {
-        int i = 0;
+        uint32_t i = 0;
         uint8_t buffer1[] = {
             /* 0x63,0x82,0x53,0x63,// MAGIC COOCKIE */
             /* 0x35,0x01,0x03,     // DHCP REQUEST */
@@ -208,7 +211,7 @@ START_TEST (test_dhcp)
     fail_unless(stored_ipv4->addr == dn->ciaddr.addr, "DCHP SERVER -> new ip not stored in negotiation data");
 
     /* check if state is changed and reply is received  */
-    len = pico_mock_network_read(mock, buf, BUFLEN);
+    len =(uint32_t) pico_mock_network_read(mock, buf, BUFLEN);
     fail_unless(len, "received msg on network of %d bytes", len);
     printbuf(&(buf[0]), len, "DHCP-OFFER msg", printbufactive);
     fail_unless(buf[0x011c] == 0x02, "No DHCP offer received after discovery");
@@ -226,9 +229,9 @@ START_TEST (test_dhcp)
 
     /* check if state is changed and reply is received  */
     do {
-        len = pico_mock_network_read(mock, buf, BUFLEN);
+        len = (uint32_t)pico_mock_network_read(mock, buf, BUFLEN);
     } while (buf[0] == 0x33);
-    printf("Received message: %d bytes\n");
+    printf("Received message: %d bytes\n", len);
     fail_unless(len, "received msg on network of %d bytes", len);
     printbuf(&(buf[0]), len, "DHCP-ACK msg", printbufactive);
     fail_unless(buf[0x11c] == 0x05, "No DHCP ACK received after discovery");

--- a/test/unit/unit_dns.c
+++ b/test/unit/unit_dns.c
@@ -39,9 +39,6 @@ START_TEST (test_dns)
     ret = pico_dns_client_nameserver(NULL, 99);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
-    ret = pico_dns_client_nameserver(NULL, (uint8_t)-99);
-    fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
-
     ret = pico_dns_client_nameserver(&ns, PICO_DNS_NS_DEL); /* delete non added ns */
     fail_if(ret == 0, "dns> dns_client_nameserver del error");
 

--- a/test/unit/unit_dns.c
+++ b/test/unit/unit_dns.c
@@ -39,7 +39,7 @@ START_TEST (test_dns)
     ret = pico_dns_client_nameserver(NULL, 99);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
-    ret = pico_dns_client_nameserver(NULL, (uint8_t)-99);
+    ret = pico_dns_client_nameserver(NULL, 0xFF);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
     ret = pico_dns_client_nameserver(&ns, PICO_DNS_NS_DEL); /* delete non added ns */

--- a/test/unit/unit_dns.c
+++ b/test/unit/unit_dns.c
@@ -1,3 +1,4 @@
+void cb_dns(char *ip, void *arg);
 
 void cb_dns(char *ip, void *arg)
 {
@@ -38,7 +39,7 @@ START_TEST (test_dns)
     ret = pico_dns_client_nameserver(NULL, 99);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
-    ret = pico_dns_client_nameserver(NULL, -99);
+    ret = pico_dns_client_nameserver(NULL, (uint8_t)-99);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
     ret = pico_dns_client_nameserver(&ns, PICO_DNS_NS_DEL); /* delete non added ns */

--- a/test/unit/unit_dns.c
+++ b/test/unit/unit_dns.c
@@ -39,6 +39,9 @@ START_TEST (test_dns)
     ret = pico_dns_client_nameserver(NULL, 99);
     fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
 
+    ret = pico_dns_client_nameserver(NULL, (uint8_t)-99);
+    fail_if(ret == 0, "dns> dns_client_nameserver wrong code");
+
     ret = pico_dns_client_nameserver(&ns, PICO_DNS_NS_DEL); /* delete non added ns */
     fail_if(ret == 0, "dns> dns_client_nameserver del error");
 

--- a/test/unit/unit_icmp4.c
+++ b/test/unit/unit_icmp4.c
@@ -237,9 +237,6 @@ START_TEST (test_icmp4_unreachable_send)
     };
 
     struct pico_frame*f = PICO_ZALLOC(sizeof(struct pico_frame));
-#ifdef NOPE
-    uint8_t nullbuf[8] = {};
-#endif
     printf("*********************** starting %s * \n", __func__);
 
     f->net_hdr = buffer;
@@ -323,11 +320,6 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_icmp_type(mock, buffer2, len) == 3); /* destination unreachable */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 2); /* proto unreachable */
     fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
-
-#ifdef NOPE
-    /* I don't know what was the intention, but the buffer is shorter than 48 bytes... */
-    fail_if(memcmp(buffer + 48, nullbuf, 8) == 0); /* there was no data */
-#endif
 }
 END_TEST
 

--- a/test/unit/unit_icmp4.c
+++ b/test/unit/unit_icmp4.c
@@ -3,6 +3,9 @@
 #define NUM_PING 1
 int ping_test_var = 0;
 
+void cb_ping(struct pico_icmp4_stats *s);
+void icmp4_unreach_socket_cb(uint16_t ev, struct pico_socket *s);
+
 void cb_ping(struct pico_icmp4_stats *s)
 {
     char host[30];
@@ -74,14 +77,14 @@ START_TEST (test_icmp4_ping)
     pico_stack_tick();
 
     /* get the packet from the mock_device */
-    memset(buffer, 0, bufferlen);
+    memset(buffer, 0, (size_t)bufferlen);
     len = pico_mock_network_read(mock, buffer, bufferlen);
     fail_if(len < 20);
     /* inspect it */
     fail_unless(mock_ip_protocol(mock, buffer, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer, len) == 8);
     fail_unless(mock_icmp_code(mock, buffer, len) == 0);
-    fail_unless(pico_checksum(buffer + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer + 20, (uint32_t)(len - 20)) == 0);
 
     /* cobble up a reply */
     buffer[20] = 0; /* type 0 : reply */
@@ -105,20 +108,20 @@ START_TEST (test_icmp4_ping)
     pico_stack_tick();
 
     /* get the packet from the mock_device */
-    memset(buffer, 0, bufferlen);
+    memset(buffer, 0, (size_t)bufferlen);
     len = pico_mock_network_read(mock, buffer, bufferlen);
     /* inspect it */
     fail_unless(mock_ip_protocol(mock, buffer, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer, len) == 8);
     fail_unless(mock_icmp_code(mock, buffer, len) == 0);
-    fail_unless(pico_checksum(buffer + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer + 20, (uint32_t)(len - 20)) == 0);
 
     /* cobble up a reply */
     buffer[20] = 0; /* type 0 : reply */
     memcpy(temp_buf, buffer + 12, 4);
     memcpy(buffer + 12, buffer + 16, 4);
     memcpy(buffer + 16, temp_buf, 4);
-    buffer[26] = ~buffer[26]; /* flip some bits in the sequence number, to see if the packet gets ignored properly */
+    buffer[26] = (uint8_t)~buffer[26]; /* flip some bits in the sequence number, to see if the packet gets ignored properly */
 
     /* using the mock-device because otherwise I have to put everything in a pico_frame correctly myself. */
     pico_mock_network_write(mock, buffer, len);
@@ -201,7 +204,7 @@ START_TEST (test_icmp4_incoming_ping)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 0);
     fail_unless(mock_icmp_code(mock, buffer2, len) == 0);
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
 }
 END_TEST
@@ -234,7 +237,9 @@ START_TEST (test_icmp4_unreachable_send)
     };
 
     struct pico_frame*f = PICO_ZALLOC(sizeof(struct pico_frame));
+#ifdef NOPE
     uint8_t nullbuf[8] = {};
+#endif
     printf("*********************** starting %s * \n", __func__);
 
     f->net_hdr = buffer;
@@ -259,7 +264,7 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 3); /* destination unreachable */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 1); /* host unreachable */
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
 
     fail_if(pico_icmp4_port_unreachable(f));
@@ -273,7 +278,7 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 3); /* destination unreachable */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 3); /* port unreachable */
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
 
     fail_if(pico_icmp4_proto_unreachable(f));
@@ -287,7 +292,7 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 3); /* destination unreachable */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 2); /* proto unreachable */
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
 
     fail_if(pico_icmp4_ttl_expired(f));
@@ -301,7 +306,7 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 11); /* ttl expired */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 0);
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
     f->net_hdr = buffer3;
     f->buffer = buffer3;
@@ -317,7 +322,7 @@ START_TEST (test_icmp4_unreachable_send)
     fail_unless(mock_ip_protocol(mock, buffer2, len) == 1);
     fail_unless(mock_icmp_type(mock, buffer2, len) == 3); /* destination unreachable */
     fail_unless(mock_icmp_code(mock, buffer2, len) == 2); /* proto unreachable */
-    fail_unless(pico_checksum(buffer2 + 20, len - 20) == 0);
+    fail_unless(pico_checksum(buffer2 + 20, (uint32_t)(len - 20)) == 0);
 
 #ifdef NOPE
     /* I don't know what was the intention, but the buffer is shorter than 48 bytes... */

--- a/test/unit/unit_ipv4.c
+++ b/test/unit/unit_ipv4.c
@@ -381,24 +381,31 @@ START_TEST (test_igmp_sockopts)
     struct pico_socket *s, *s1 = NULL;
     struct pico_device *dev = NULL;
     union pico_address *source = NULL;
-    union pico_address
-	inaddr_dst = {},
-	inaddr_incorrect = {},
-	inaddr_uni = {},
-	inaddr_null = {},
-	netmask = {};
-    union pico_address inaddr_link[2] = {};
-    union pico_address inaddr_mcast[8] = {};
-    union pico_address inaddr_source[8] = {};
-    struct pico_ip_mreq _mreq = {}, mreq[16] = {};
-    struct pico_ip_mreq_source mreq_source[128] = {};
+    union pico_address inaddr_dst = {
+        0
+    }, inaddr_incorrect = {
+        0
+    }, inaddr_uni = {
+        0
+    }, inaddr_null = {
+        0
+    }, netmask = {
+        0
+    };
+    union pico_address inaddr_link[2] = {0};
+    union pico_address inaddr_mcast[8] = {0};
+    union pico_address inaddr_source[8] = {0};
+    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
+    struct pico_ip_mreq_source mreq_source[128] = {0};
     struct pico_tree_node *index = NULL;
 
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    union pico_address mcast_def_link = {};
+    union pico_address mcast_def_link = {
+        0
+    };
 
     pico_stack_init();
 

--- a/test/unit/unit_ipv4.c
+++ b/test/unit/unit_ipv4.c
@@ -381,31 +381,24 @@ START_TEST (test_igmp_sockopts)
     struct pico_socket *s, *s1 = NULL;
     struct pico_device *dev = NULL;
     union pico_address *source = NULL;
-    union pico_address inaddr_dst = {
-        0
-    }, inaddr_incorrect = {
-        0
-    }, inaddr_uni = {
-        0
-    }, inaddr_null = {
-        0
-    }, netmask = {
-        0
-    };
-    union pico_address inaddr_link[2] = {0};
-    union pico_address inaddr_mcast[8] = {0};
-    union pico_address inaddr_source[8] = {0};
-    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
-    struct pico_ip_mreq_source mreq_source[128] = {0};
+    union pico_address
+	inaddr_dst = {},
+	inaddr_incorrect = {},
+	inaddr_uni = {},
+	inaddr_null = {},
+	netmask = {};
+    union pico_address inaddr_link[2] = {};
+    union pico_address inaddr_mcast[8] = {};
+    union pico_address inaddr_source[8] = {};
+    struct pico_ip_mreq _mreq = {}, mreq[16] = {};
+    struct pico_ip_mreq_source mreq_source[128] = {};
     struct pico_tree_node *index = NULL;
 
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    union pico_address mcast_def_link = {
-        0
-    };
+    union pico_address mcast_def_link = {};
 
     pico_stack_init();
 

--- a/test/unit/unit_ipv4.c
+++ b/test/unit/unit_ipv4.c
@@ -2,7 +2,7 @@
 START_TEST (test_ipv4)
 {
   #define IP_TST_SIZ 256
-    int i;
+    uint32_t i;
 
     struct pico_device *dev[IP_TST_SIZ];
     char devname[8];
@@ -24,14 +24,14 @@ START_TEST (test_ipv4)
     for (i = 0; i < IP_TST_SIZ; i++) {
         snprintf(devname, 8, "nul%d", i);
         dev[i] = pico_null_create(devname);
-        a[i].addr = long_be(0x0a000001 + (i << 16));
-        d[i].addr = long_be(0x0a000002 + (i << 16));
+        a[i].addr = long_be(0x0a000001u + (i << 16));
+        d[i].addr = long_be(0x0a000002u + (i << 16));
         fail_if(pico_ipv4_link_add(dev[i], a[i], nm16) != 0, "Error adding link");
     }
     /*link_find + link_get + route_add*/
     for (i = 0; i < IP_TST_SIZ; i++) {
-        gw[i].addr = long_be(0x0a0000f0 + (i << 16));
-        r[i].addr = long_be(0x0c00001 + (i << 16));
+        gw[i].addr = long_be(0x0a0000f0u + (i << 16));
+        r[i].addr = long_be(0x0c00001u + (i << 16));
         fail_unless(pico_ipv4_link_find(&a[i]) == dev[i], "Error finding link");
         l[i] = pico_ipv4_link_get(&a[i]);
         fail_if(l[i] == NULL, "Error getting link");
@@ -80,7 +80,7 @@ START_TEST (test_nat_enable_disable)
     struct pico_frame *f = pico_ipv4_alloc(&pico_proto_ipv4, PICO_UDPHDR_SIZE);
     struct pico_ipv4_hdr *net = (struct pico_ipv4_hdr *)f->net_hdr;
     struct pico_udp_hdr *udp = (struct pico_udp_hdr *)f->transport_hdr;
-    char *raw_data = "ello";
+    const char *raw_data = "ello";
 
     net->vhl = 0x45; /* version = 4, hdr len = 5 (32-bit words) */
     net->tos = 0;
@@ -90,7 +90,6 @@ START_TEST (test_nat_enable_disable)
     net->ttl = 64;
     net->proto = 17; /* UDP */
     net->crc = 0;
-    net->crc = pico_ipv4_checksum(f);
     net->src.addr = long_be(0x0a280008); /* 10.40.0.8 */
     net->dst.addr = long_be(0x0a320001); /* 10.50.0.1 */
 
@@ -134,7 +133,7 @@ START_TEST (test_nat_translation)
     struct pico_ip4 nat = {
         .addr = long_be(0x0a320001)
     };                                                  /* 10.50.0.9 */
-    char *raw_data = "ello";
+    const char *raw_data = "ello";
     uint16_t sport_ori = short_be(5555);
     uint16_t dport_ori = short_be(6667);
     uint16_t nat_port = 0;
@@ -147,7 +146,6 @@ START_TEST (test_nat_translation)
     net->ttl = 64;
     net->proto = 17; /* UDP */
     net->crc = 0;
-    net->crc = pico_ipv4_checksum(f);
     net->src = src_ori;
     net->dst = dst_ori;
 
@@ -215,7 +213,7 @@ START_TEST (test_nat_port_forwarding)
     struct pico_ip4 nat_addr = {
         .addr = long_be(0x0a320001)
     };                                                       /* 10.50.0.9 */
-    char *raw_data = "ello";
+    const char *raw_data = "ello";
     uint16_t sport_ori = short_be(5555);
     uint16_t fport_pub = short_be(80);
     uint16_t fport_priv = short_be(8080);
@@ -228,7 +226,6 @@ START_TEST (test_nat_port_forwarding)
     net->ttl = 64;
     net->proto = 17; /* UDP */
     net->crc = 0;
-    net->crc = pico_ipv4_checksum(f);
     net->src = dst_addr;
     net->dst = nat_addr;
 
@@ -278,7 +275,7 @@ START_TEST (test_ipfilter)
 
     enum filter_action action = 1;
 
-    int filter_id1;
+    uint32_t filter_id1;
 
     /* 192.168.1.2:16415 -> 192.168.1.109:1222 [sending a TCP syn] */
     uint8_t ipv4_buf[] = {
@@ -298,7 +295,7 @@ START_TEST (test_ipfilter)
     printf("filter_id1 = %d\n", filter_id1);
 
     printf("IP Filter> Trying to add the same filter...\n");
-    ret = pico_ipv4_filter_add(dev, proto, &src_addr, &saddr_netmask, &dst_addr, &daddr_netmask, sport, dport, priority, tos, action);
+    filter_id1 = pico_ipv4_filter_add(dev, proto, &src_addr, &saddr_netmask, &dst_addr, &daddr_netmask, sport, dport, priority, tos, action);
     fail_if(ret > 0, "Error adding filter\n");
 
     printf("IP Filter> Deleting added filter...\n");
@@ -395,18 +392,18 @@ START_TEST (test_igmp_sockopts)
     }, netmask = {
         0
     };
-    union pico_address inaddr_link[2] = {{0}};
-    union pico_address inaddr_mcast[8] = {{0}};
-    union pico_address inaddr_source[8] = {{0}};
-    struct pico_ip_mreq _mreq = {{0}}, mreq[16] = {{{0}}};
-    struct pico_ip_mreq_source mreq_source[128] = {{{0}}};
+    union pico_address inaddr_link[2] = {0};
+    union pico_address inaddr_mcast[8] = {0};
+    union pico_address inaddr_source[8] = {0};
+    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
+    struct pico_ip_mreq_source mreq_source[128] = {0};
     struct pico_tree_node *index = NULL;
 
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    union pico_address mcast_default_link = {
+    union pico_address mcast_def_link = {
         0
     };
 
@@ -471,9 +468,9 @@ START_TEST (test_igmp_sockopts)
 
     /* argument validation tests */
     printf("IGMP SETOPTION ARGUMENT VALIDATION TEST\n");
-    ret = pico_socket_setoption(s, PICO_IP_MULTICAST_IF, &mcast_default_link);
+    ret = pico_socket_setoption(s, PICO_IP_MULTICAST_IF, &mcast_def_link);
     fail_if(ret == 0, "unsupported PICO_IP_MULTICAST_IF succeeded\n");
-    ret = pico_socket_getoption(s, PICO_IP_MULTICAST_IF, &mcast_default_link);
+    ret = pico_socket_getoption(s, PICO_IP_MULTICAST_IF, &mcast_def_link);
     fail_if(ret == 0, "unsupported PICO_IP_MULTICAST_IF succeeded\n");
     ret = pico_socket_setoption(s, PICO_IP_MULTICAST_TTL, &ttl);
     fail_if(ret < 0, "supported PICO_IP_MULTICAST_TTL failed\n");

--- a/test/unit/unit_ipv6.c
+++ b/test/unit/unit_ipv6.c
@@ -319,25 +319,31 @@ START_TEST (test_mld_sockopts)
     struct pico_socket *s, *s1 = NULL;
     struct pico_device *dev = NULL;
     union pico_address *source = NULL;
-    union pico_address
-	inaddr_dst = {},
-	inaddr_incorrect = {},
-	inaddr_uni = {},
-	inaddr_null = {};
+    union pico_address inaddr_dst = {
+        {0}
+    }, inaddr_incorrect = {
+        {0}
+    }, inaddr_uni = {
+        {0}
+    }, inaddr_null = {
+        {0}
+    };
     struct pico_ip6 netmask = {{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }};
 
-    union pico_address inaddr_link[2] = {};
-    union pico_address inaddr_mcast[8] = {};
-    union pico_address inaddr_source[8] = {};
-    struct pico_ip_mreq _mreq = {}, mreq[16] = {};
-    struct pico_ip_mreq_source mreq_source[128] = {};
+    union pico_address inaddr_link[2] = {0};
+    union pico_address inaddr_mcast[8] = {0};
+    union pico_address inaddr_source[8] = {0};
+    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
+    struct pico_ip_mreq_source mreq_source[128] = {0};
     struct pico_tree_node *index = NULL;
     struct pico_ipv6_link *ret_link = NULL;
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    struct pico_ip6 mcast_def_link = {};
+    struct pico_ip6 mcast_def_link = {
+        0
+    };
 
     pico_stack_init();
 

--- a/test/unit/unit_ipv6.c
+++ b/test/unit/unit_ipv6.c
@@ -319,31 +319,25 @@ START_TEST (test_mld_sockopts)
     struct pico_socket *s, *s1 = NULL;
     struct pico_device *dev = NULL;
     union pico_address *source = NULL;
-    union pico_address inaddr_dst = {
-        {0}
-    }, inaddr_incorrect = {
-        {0}
-    }, inaddr_uni = {
-        {0}
-    }, inaddr_null = {
-        {0}
-    };
+    union pico_address
+	inaddr_dst = {},
+	inaddr_incorrect = {},
+	inaddr_uni = {},
+	inaddr_null = {};
     struct pico_ip6 netmask = {{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }};
 
-    union pico_address inaddr_link[2] = {0};
-    union pico_address inaddr_mcast[8] = {0};
-    union pico_address inaddr_source[8] = {0};
-    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
-    struct pico_ip_mreq_source mreq_source[128] = {0};
+    union pico_address inaddr_link[2] = {};
+    union pico_address inaddr_mcast[8] = {};
+    union pico_address inaddr_source[8] = {};
+    struct pico_ip_mreq _mreq = {}, mreq[16] = {};
+    struct pico_ip_mreq_source mreq_source[128] = {};
     struct pico_tree_node *index = NULL;
     struct pico_ipv6_link *ret_link = NULL;
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    struct pico_ip6 mcast_def_link = {
-        0
-    };
+    struct pico_ip6 mcast_def_link = {};
 
     pico_stack_init();
 

--- a/test/unit/unit_ipv6.c
+++ b/test/unit/unit_ipv6.c
@@ -320,13 +320,13 @@ START_TEST (test_mld_sockopts)
     struct pico_device *dev = NULL;
     union pico_address *source = NULL;
     union pico_address inaddr_dst = {
-        {0}
+        0
     }, inaddr_incorrect = {
-        {0}
+        0
     }, inaddr_uni = {
-        {0}
+        0
     }, inaddr_null = {
-        {0}
+        0
     };
     struct pico_ip6 netmask = {{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }};
 

--- a/test/unit/unit_ipv6.c
+++ b/test/unit/unit_ipv6.c
@@ -225,18 +225,18 @@ START_TEST (test_ipv6)
         snprintf(devname, 8, "nul%d", i);
         dev[i] = pico_null_create(devname);
         a[i] = iphex_a;
-        a[i].addr[4] += i;
+        a[i].addr[4] = (uint8_t)(a[i].addr[4] + i);
         fail_if(pico_ipv6_link_add(dev[i], a[i], nm64) == NULL, "Error adding link");
     }
     /*link_find + link_get + route_add*/
     for (i = 0; i < 10; ++i) {
         gw[i] = iphex_gw;
-        gw[i].addr[4] += i;
+        gw[i].addr[4] = (uint8_t)(gw[i].addr[4] + i);
         fail_unless(pico_ipv6_link_find(&a[i]) == dev[i], "Error finding link");
         l[i] = pico_ipv6_link_get(&a[i]);
         fail_if(l[i] == NULL, "Error getting link");
         r[i] = iphex_r;
-        r[i].addr[4] += i;
+        r[i].addr[4] = (uint8_t)(r[i].addr[4] + i);
         fail_if(pico_ipv6_route_add(r[i], nm128, a[i], 1, l[i]) != 0, "Error adding route");
     }
     /*get_gateway*/
@@ -330,18 +330,18 @@ START_TEST (test_mld_sockopts)
     };
     struct pico_ip6 netmask = {{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }};
 
-    union pico_address inaddr_link[2] = {{0}};
-    union pico_address inaddr_mcast[8] = {{0}};
-    union pico_address inaddr_source[8] = {{0}};
-    struct pico_ip_mreq _mreq = {{0}}, mreq[16] = {{{0}}};
-    struct pico_ip_mreq_source mreq_source[128] = {{{0}}};
+    union pico_address inaddr_link[2] = {0};
+    union pico_address inaddr_mcast[8] = {0};
+    union pico_address inaddr_source[8] = {0};
+    struct pico_ip_mreq _mreq = {0}, mreq[16] = {0};
+    struct pico_ip_mreq_source mreq_source[128] = {0};
     struct pico_tree_node *index = NULL;
-
+    struct pico_ipv6_link *ret_link = NULL;
     int ttl = 64;
     int getttl = 0;
     int loop = 9;
     int getloop = 0;
-    struct pico_ip6 mcast_default_link = {
+    struct pico_ip6 mcast_def_link = {
         0
     };
 
@@ -390,11 +390,11 @@ START_TEST (test_mld_sockopts)
         }
     }
     dev = pico_null_create("dummy0");
-    ret = pico_ipv6_link_add(dev, inaddr_link[0].ip6, netmask);
-    fail_if(ret == NULL, "link add failed");
+    ret_link = pico_ipv6_link_add(dev, inaddr_link[0].ip6, netmask);
+    fail_if(ret_link == NULL, "link add failed");
     dev = pico_null_create("dummy1");
-    ret = pico_ipv6_link_add(dev, inaddr_link[1].ip6, netmask);
-    fail_if(ret == NULL, "link add failed");
+    ret_link = pico_ipv6_link_add(dev, inaddr_link[1].ip6, netmask);
+    fail_if(ret_link == NULL, "link add failed");
 
 
     s = pico_socket_open(PICO_PROTO_IPV6, PICO_PROTO_UDP, NULL);
@@ -405,9 +405,9 @@ START_TEST (test_mld_sockopts)
 
     /* argument validation tests */
     printf("MLD SETOPTION ARGUMENT VALIDATION TEST\n");
-    ret = pico_socket_setoption(s, PICO_IP_MULTICAST_IF, &mcast_default_link);
+    ret = pico_socket_setoption(s, PICO_IP_MULTICAST_IF, &mcast_def_link);
     fail_if(ret == 0, "unsupported PICO_IP_MULTICAST_IF succeeded\n");
-    ret = pico_socket_getoption(s, PICO_IP_MULTICAST_IF, &mcast_default_link);
+    ret = pico_socket_getoption(s, PICO_IP_MULTICAST_IF, &mcast_def_link);
     fail_if(ret == 0, "unsupported PICO_IP_MULTICAST_IF succeeded\n");
     ret = pico_socket_setoption(s, PICO_IP_MULTICAST_TTL, &ttl);
     fail_if(ret < 0, "supported PICO_IP_MULTICAST_TTL failed\n");

--- a/test/unit/unit_mocks.c
+++ b/test/unit/unit_mocks.c
@@ -1,5 +1,9 @@
 #define BUFLEN (576 + 14 + 20 + 8)
 
+int mock_print_protocol(uint8_t *buf);
+int printbuf(uint8_t *buf, uint32_t len, const char *str, uint8_t printbufactive);
+int tick_it(uint32_t nticks);
+
 int mock_print_protocol(uint8_t *buf)
 {
     uint8_t pnr = buf[0x17]; /* protocol number */
@@ -14,7 +18,7 @@ int mock_print_protocol(uint8_t *buf)
     return 0;
 }
 
-int printbuf(uint8_t *buf, uint32_t len, char *str, uint8_t printbufactive)
+int printbuf(uint8_t *buf, uint32_t len, const char *str, uint8_t printbufactive)
 {
     uint8_t printMethod = 0;
     uint32_t cntr = 0;

--- a/test/unit/unit_rbtree.c
+++ b/test/unit/unit_rbtree.c
@@ -4,6 +4,8 @@ typedef struct
     int value;
 }elem;
 
+int compare(void *a, void *b);
+
 int compare(void *a, void *b)
 {
     return ((elem *)a)->value - ((elem *)b)->value;
@@ -25,7 +27,7 @@ START_TEST (test_rbtree2)
     for (i = 0; i < (RBTEST_SIZE >> 1); i++)
     {
         e = malloc(sizeof(elem));
-        e->value = lrand48() % RBTEST_SIZE;
+        e->value = (int)lrand48() % RBTEST_SIZE;
         if (pico_tree_findKey(&test_tree2, e)) {
             free(e);
         } else {

--- a/test/unit/unit_socket.c
+++ b/test/unit/unit_socket.c
@@ -39,8 +39,15 @@ START_TEST (test_socket)
     s = pico_socket_open(PICO_PROTO_IPV4, 99, NULL);
     fail_if(s != NULL, "Error got socket wrong parameters");
 
+    s = pico_socket_open(PICO_PROTO_IPV4, (uint16_t)-109, NULL);
+    fail_if(s != NULL, "Error got socket");
+
     s = pico_socket_open(99, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
+
+    s = pico_socket_open((uint16_t)-99, PICO_PROTO_UDP, NULL);
+    fail_if(s != NULL, "Error got socket");
+
 
     sk_tcp = pico_socket_open(PICO_PROTO_IPV4, PICO_PROTO_TCP, NULL);
     fail_if(sk_tcp == NULL, "socket> tcp socket open failed");
@@ -192,6 +199,8 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
+    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
+    fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));
     fail_if(ret <= 0, "socket> udp socket sendto failed, ret = %d: %s\n", ret, strerror(pico_err));
@@ -270,6 +279,8 @@ START_TEST (test_socket)
     ret = pico_socket_sendto(sk_udp, (void *)buf, 0, &inaddr_dst, port_be);
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), NULL, port_be);
+    fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
+    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));

--- a/test/unit/unit_socket.c
+++ b/test/unit/unit_socket.c
@@ -39,13 +39,13 @@ START_TEST (test_socket)
     s = pico_socket_open(PICO_PROTO_IPV4, 99, NULL);
     fail_if(s != NULL, "Error got socket wrong parameters");
 
-    s = pico_socket_open(PICO_PROTO_IPV4, -109, NULL);
+    s = pico_socket_open(PICO_PROTO_IPV4, (uint16_t)-109, NULL);
     fail_if(s != NULL, "Error got socket");
 
     s = pico_socket_open(99, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
 
-    s = pico_socket_open(-99, PICO_PROTO_UDP, NULL);
+    s = pico_socket_open((uint16_t)-99, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
 
 
@@ -199,7 +199,7 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, -120);
+    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));
@@ -280,7 +280,7 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, -120);
+    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));

--- a/test/unit/unit_socket.c
+++ b/test/unit/unit_socket.c
@@ -39,15 +39,8 @@ START_TEST (test_socket)
     s = pico_socket_open(PICO_PROTO_IPV4, 99, NULL);
     fail_if(s != NULL, "Error got socket wrong parameters");
 
-    s = pico_socket_open(PICO_PROTO_IPV4, (uint16_t)-109, NULL);
-    fail_if(s != NULL, "Error got socket");
-
     s = pico_socket_open(99, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
-
-    s = pico_socket_open((uint16_t)-99, PICO_PROTO_UDP, NULL);
-    fail_if(s != NULL, "Error got socket");
-
 
     sk_tcp = pico_socket_open(PICO_PROTO_IPV4, PICO_PROTO_TCP, NULL);
     fail_if(sk_tcp == NULL, "socket> tcp socket open failed");
@@ -199,8 +192,6 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
-    fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));
     fail_if(ret <= 0, "socket> udp socket sendto failed, ret = %d: %s\n", ret, strerror(pico_err));
@@ -279,8 +270,6 @@ START_TEST (test_socket)
     ret = pico_socket_sendto(sk_udp, (void *)buf, 0, &inaddr_dst, port_be);
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), NULL, port_be);
-    fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));

--- a/test/unit/unit_socket.c
+++ b/test/unit/unit_socket.c
@@ -39,13 +39,13 @@ START_TEST (test_socket)
     s = pico_socket_open(PICO_PROTO_IPV4, 99, NULL);
     fail_if(s != NULL, "Error got socket wrong parameters");
 
-    s = pico_socket_open(PICO_PROTO_IPV4, (uint16_t)-109, NULL);
+    s = pico_socket_open(PICO_PROTO_IPV4, 0xFFFF, NULL);
     fail_if(s != NULL, "Error got socket");
 
     s = pico_socket_open(99, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
 
-    s = pico_socket_open((uint16_t)-99, PICO_PROTO_UDP, NULL);
+    s = pico_socket_open(0xFFFF, PICO_PROTO_UDP, NULL);
     fail_if(s != NULL, "Error got socket");
 
 
@@ -199,7 +199,7 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
+    ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, 0xFFFF);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_tcp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));
@@ -280,7 +280,7 @@ START_TEST (test_socket)
     fail_if(ret > 0, "Error socket sendto succeeded, wrong argument\n");
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), NULL, port_be);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
-    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, (uint16_t)-120);
+    ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, 0xFFFF);
     fail_if(ret >= 0, "Error socket sendto succeeded, wrong argument\n");
     /* socket_write passing correct parameters */
     ret = pico_socket_sendto(sk_udp, (void *)buf, sizeof(buf), &inaddr_dst, short_be(5555));

--- a/test/unit/unit_timer.c
+++ b/test/unit/unit_timer.c
@@ -7,14 +7,21 @@ START_TEST (test_timers)
     int i;
     pico_stack_init();
     for (i = 0; i < 128; i++) {
-        T[i] = pico_timer_add(999999 + i, 0xff00 + i, 0xaa00 + i);
-        printf("New timer %lu\n", T[i]);
+        pico_time expire = (pico_time)(999999 + i);
+        void (*timer)(pico_time, void *) =(void (*)(pico_time, void *))0xff00 + i;
+        void *arg = ((void*)0xaa00 + i);
+
+        T[i] = pico_timer_add(expire, timer, arg);
+        printf("New timer %u\n", T[i]);
     }
     for (i = 0; i < 128; i++) {
-        fail_if(i + 1 > Timers->n);
+        void (*timer)(pico_time, void *) =(void (*)(pico_time, void *))0xff00 + i;
+        void *arg = ((void*)0xaa00 + i);
+
+        fail_if((uint32_t)(i + 1) > Timers->n);
         fail_unless(Timers->top[i + EXISTING_TIMERS].id == T[i]);
-        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->timer == (0xff00 + i));
-        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->arg == (0xaa00 + i));
+        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->timer == timer);
+        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->arg == arg);
     }
     for (i = 127; i >= 0; i--) {
         printf("Deleting timer %d \n", i );

--- a/test/units.c
+++ b/test/units.c
@@ -68,6 +68,8 @@
 #include "unit_arp.c"
 #include "unit_ipv6.c"
 
+Suite *pico_suite(void);
+
 START_TEST (test_frame)
 {
     struct pico_frame *f1;


### PR DESCRIPTION
Related to issue #419 .

This should fix the warnings in the unit tests.

For the changes in the dns module, I understood from the discussion in the issue that we allow this in the API.
I changed the pico_dns_name_to_dns_notation, ... and some others to accept uint16_t instead of unsigned int. Internally, the unsigned int that is accepted is cast to uin16_t and the dns module has a pico_dns_strlen() function that returns uint16_t. Sizes of strings in the dns module are always presumed to fit in uint16_t.
I can understand that explicitly stating uint16_t in the API may reveal some internal functionality, but this could warn the user for some nasty surprises if it is passed something smaller. I would propose to keep this change in as it is clear to the user what we expect and support. @frederikvs , what is your view on this?