### PR TITLE
Heap should use separate blocks of memory

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -13,12 +13,12 @@
         type *top[MAX_BLOCK_COUNT];        \
     }; \
     typedef struct heap_ ## type heap_ ## type; \
-    static inline type* getElement(struct heap_ ## type *heap, uint32_t idx) \
+    static inline type* heap_get_element(struct heap_ ## type *heap, uint32_t idx) \
     { \
         uint32_t elements_per_block = MAX_BLOCK_SIZE/sizeof(type); \
         return &heap->top[idx/elements_per_block][idx%elements_per_block];\
     } \
-    static inline int8_t increase_size(struct heap_ ## type *heap) \
+    static inline int8_t heap_increase_size(struct heap_ ## type *heap) \
     {\
         type *newTop; \
         uint32_t elements_per_block = MAX_BLOCK_SIZE/sizeof(type); \
@@ -41,26 +41,26 @@
     }\
     static inline int heap_insert(struct heap_ ## type *heap, type * el) \
     { \
-        type* half;                                                                 \
+        type *half;                                                                 \
         uint32_t i; \
         if (++heap->n >= heap->size) {                                                \
-            if (increase_size(heap)){                                                    \
+            if (heap_increase_size(heap)){                                                    \
                 heap->n--;                                                           \
                 return -1;                                                           \
             }                                                                       \
         }                                                                             \
         if (heap->n == 1) {                                                       \
-            memcpy(getElement(heap, 1), el, sizeof(type));                                    \
+            memcpy(heap_get_element(heap, 1), el, sizeof(type));                                    \
             return 0;                                                                   \
         }                                                                             \
         i = heap->n;                                                                    \
-        half = getElement(heap, i/2);                                                   \
+        half = heap_get_element(heap, i/2);                                                   \
         while ( (i > 1) && (half->orderby > el->orderby) ) {        \
-            memcpy(getElement(heap, i), getElement(heap, i / 2), sizeof(type));                     \
+            memcpy(heap_get_element(heap, i), heap_get_element(heap, i / 2), sizeof(type));                     \
             i /= 2;                                                                     \
-            half = getElement(heap, i/2);                                                   \
+            half = heap_get_element(heap, i/2);                                                   \
         }             \
-        memcpy(getElement(heap, i), el, sizeof(type));                                      \
+        memcpy(heap_get_element(heap, i), el, sizeof(type));                                      \
         return 0;                                                                     \
     } \
     static inline int heap_peek(struct heap_ ## type *heap, type * first) \
@@ -72,32 +72,32 @@
         if(heap->n == 0) {    \
             return -1;          \
         }                     \
-        memcpy(first, getElement(heap, 1), sizeof(type));   \
-        last = getElement(heap, heap->n--);                 \
+        memcpy(first, heap_get_element(heap, 1), sizeof(type));   \
+        last = heap_get_element(heap, heap->n--);                 \
         for(i = 1; (i * 2u) <= heap->n; i = child) {   \
             child = 2u * i;                              \
-            right_child = getElement(heap, child+1);     \
-            left_child = getElement(heap, child);      \
+            right_child = heap_get_element(heap, child+1);     \
+            left_child = heap_get_element(heap, child);      \
             if ((child != heap->n) &&                   \
                 (right_child->orderby          \
                 < left_child->orderby))           \
                 child++;                                \
-            left_child = getElement(heap, child);      \
+            left_child = heap_get_element(heap, child);      \
             if (last->orderby >                         \
                 left_child->orderby)               \
-                memcpy(getElement(heap,i), getElement(heap,child), \
+                memcpy(heap_get_element(heap,i), heap_get_element(heap,child), \
                        sizeof(type));                  \
             else                                        \
                 break;                                  \
         }                                             \
-        memcpy(getElement(heap, i), last, sizeof(type));    \
+        memcpy(heap_get_element(heap, i), last, sizeof(type));    \
         return 0;                                     \
     } \
     static inline type *heap_first(heap_ ## type * heap)  \
     { \
         if (heap->n == 0)     \
             return NULL;        \
-        return getElement(heap, 1);  \
+        return heap_get_element(heap, 1);  \
     } \
     static inline heap_ ## type *heap_init(void) \
     { \

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -586,17 +586,18 @@ static void pico_check_timers(void)
 void MOCKABLE pico_timer_cancel(uint32_t id)
 {
     uint32_t i;
-    struct pico_timer_ref *tref = Timers->top;
+    struct pico_timer_ref *tref;
     if (id == 0u)
         return;
 
     for (i = 1; i <= Timers->n; i++) {
-        if (tref[i].id == id) {
-            if (Timers->top[i].tmr)
+        tref = getElement(Timers, i);
+        if (tref->id == id) {
+            if (tref->tmr)
             {
-                PICO_FREE(Timers->top[i].tmr);
-                Timers->top[i].tmr = NULL;
-                tref[i].id = 0;
+                PICO_FREE(tref->tmr);
+                tref->tmr = NULL;
+                tref->id = 0;
             }
             break;
         }
@@ -606,16 +607,17 @@ void MOCKABLE pico_timer_cancel(uint32_t id)
 void pico_timer_cancel_hashed(uint32_t hash)
 {
     uint32_t i;
-    struct pico_timer_ref *tref = Timers->top;
+    struct pico_timer_ref *tref;
     if (hash == 0u)
         return;
 
     for (i = 1; i <= Timers->n; i++) {
-        if (tref[i].hash == hash) {
-            if (Timers->top[i].tmr)
+        tref = getElement(Timers, i);
+        if (tref->hash == hash) {
+            if (tref->tmr)
             {
-                PICO_FREE(Timers->top[i].tmr);
-                Timers->top[i].tmr = NULL;
+                PICO_FREE(tref->tmr);
+                tref->tmr = NULL;
                 tref[i].id = 0;
             }
         }

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -591,7 +591,7 @@ void MOCKABLE pico_timer_cancel(uint32_t id)
         return;
 
     for (i = 1; i <= Timers->n; i++) {
-        tref = getElement(Timers, i);
+        tref = heap_get_element(Timers, i);
         if (tref->id == id) {
             if (tref->tmr)
             {
@@ -612,7 +612,7 @@ void pico_timer_cancel_hashed(uint32_t hash)
         return;
 
     for (i = 1; i <= Timers->n; i++) {
-        tref = getElement(Timers, i);
+        tref = heap_get_element(Timers, i);
         if (tref->hash == hash) {
             if (tref->tmr)
             {

--- a/test/unit/unit_timer.c
+++ b/test/unit/unit_timer.c
@@ -20,7 +20,7 @@ START_TEST (test_timers)
         void *arg = ((void*)0xaa00 + i);
 
         fail_if((uint32_t)(i + 1) > Timers->n);
-        tref = getElement(Timers, (uint32_t)i + EXISTING_TIMERS);
+        tref = heap_get_element(Timers, (uint32_t)i + EXISTING_TIMERS);
         fail_unless(tref->id == T[i]);
         fail_unless(tref->tmr->timer == timer);
         fail_unless(tref->tmr->arg == arg);
@@ -29,7 +29,7 @@ START_TEST (test_timers)
         printf("Deleting timer %d \n", i );
         pico_timer_cancel(T[i]);
         printf("Deleted timer %d \n", i );
-        tref = getElement(Timers, (uint32_t)i + EXISTING_TIMERS);
+        tref = heap_get_element(Timers, (uint32_t)i + EXISTING_TIMERS);
         fail_unless(tref->tmr == NULL);
     }
     pico_stack_tick();

--- a/test/unit/unit_timer.c
+++ b/test/unit/unit_timer.c
@@ -5,6 +5,7 @@ START_TEST (test_timers)
 {
     uint32_t T[128];
     int i;
+    struct pico_timer_ref *tref;
     pico_stack_init();
     for (i = 0; i < 128; i++) {
         pico_time expire = (pico_time)(999999 + i);
@@ -19,15 +20,17 @@ START_TEST (test_timers)
         void *arg = ((void*)0xaa00 + i);
 
         fail_if((uint32_t)(i + 1) > Timers->n);
-        fail_unless(Timers->top[i + EXISTING_TIMERS].id == T[i]);
-        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->timer == timer);
-        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr->arg == arg);
+        tref = getElement(Timers, (uint32_t)i + EXISTING_TIMERS);
+        fail_unless(tref->id == T[i]);
+        fail_unless(tref->tmr->timer == timer);
+        fail_unless(tref->tmr->arg == arg);
     }
     for (i = 127; i >= 0; i--) {
         printf("Deleting timer %d \n", i );
         pico_timer_cancel(T[i]);
         printf("Deleted timer %d \n", i );
-        fail_unless(Timers->top[i + EXISTING_TIMERS].tmr == NULL);
+        tref = getElement(Timers, (uint32_t)i + EXISTING_TIMERS);
+        fail_unless(tref->tmr == NULL);
     }
     pico_stack_tick();
     pico_stack_tick();


### PR DESCRIPTION
# Background 
Our smoke tests with the MM enabled are failing. Until recently, this was hidden by #409, which was fixed by #420.
The failure is a combination of a number of factors : 

* During one of the tests (with fragmentation) we allocate quite a lot of timers. 
* Our timers use our implementation of the heap data structure. So far, this always tries to allocate enough contiguous space to store all its timers. 
* Our own memory manager can't currently allocate anything larger than 1600 bytes. Even if we were to rewrite this to also handle larger blocks, it's still limited by the page size (4096 bytes) by design.

# Solution
I solved this by modifying the heap implementation : instead of one contiguous block, it can now handle multiple blocks of a limited size.
This also cuts down a little on the memcopying when the number of timers increases : instead of always copying the whole structure, we only need to copy the last block. 


Since this is a pretty tricky bit of code, and pretty important, it would be good to get some feedback. 
Also compare to @danielinux' work over at https://github.com/danielinux/ebhita/ - it now includes a way of actually deleting an element from the heap. However, active timers can't be deleted from the heap, so we'd still be limited to a little over 60 active timers with our 1600 byte MM limit.

# Next steps
TODO : get the `MAX_BLOCK_SIZE` and `MAX_BLOCK_COUNT` in from the makefile, and probably rename these to prevent name conflicts. I'll do this when we're sure if this is the right way to go.


Future work might include changing the way we increase the number of timers. Right now, when we need to add an extra timer, we allocate enough space for adding just one timer, and then copying a bunch of stuff into the new, expanded area. We could provide extra space for a number of extra timers, right away. Not planning on doing this right now, but we should be aware of this point of potential improvement.