### PR TITLE
[6LoWPAN] - Enforced aligned access and altered socket_xmit_one

### DIFF
--- a/modules/pico_6lowpan.c
+++ b/modules/pico_6lowpan.c
@@ -29,8 +29,8 @@
 #define lp_dbg(...) do {} while(0)
 #endif
 
-#define IPV6_MCAST_48(addr) (!(*(uint16_t *)&addr[8]) && !addr[10] && (addr[11] || addr[12]))
-#define IPV6_MCAST_32(addr) (!(*(uint32_t *)&addr[8]) && !addr[12] && (addr[13] || addr[14]))
+#define IPV6_MCAST_48(addr) (!addr[8] && !addr[9] && !addr[10] && (addr[11] || addr[12]))
+#define IPV6_MCAST_32(addr) (!addr[8] && !addr[9] && !addr[10] && !addr[11] && !addr[12] && (addr[13] || addr[14]))
 #define IPV6_MCAST_8(addr)  (addr[1] == 0x02 && !addr[14] && addr[15])
 #define PORT_COMP(a, mask, b)   (((a) & (mask)) == (b))
 
@@ -271,8 +271,8 @@ static int8_t
 compressor_vtf(uint8_t *ori, uint8_t *comp, uint8_t *iphc, union pico_ll_addr *
                llsrc, union pico_ll_addr *lldst, struct pico_device *dev)
 {
-    uint32_t fl = 0, mask = long_be((uint32_t)0x000FFFFF);
     uint8_t ecn = 0, dscp = 0;
+    uint32_t fl = 0;
     *ori &= 0x0F; // Clear version field
     *iphc &= (uint8_t)0x07; // Clear IPHC field
     *iphc |= (uint8_t)IPHC_DISPATCH;
@@ -281,21 +281,25 @@ compressor_vtf(uint8_t *ori, uint8_t *comp, uint8_t *iphc, union pico_ll_addr *
     IGNORE_PARAMETER(dev);
 
     /* Don't worry... */
-    ecn = (uint8_t)(*ori << 4) & 0xC0;
-    dscp = (uint8_t)(*ori++ << 4) & 0x30;
-    dscp |= (uint8_t)((uint8_t)(*ori-- & 0xF0) >> 4);
-    fl = long_be(*(uint32_t *)ori & mask);
+    ecn = (uint8_t)((ori[0] << 4) & 0xC0);
+    dscp = (uint8_t)(((ori[0] << 4) & 0x30) | ((ori[1] & 0xF0) >> 4));
+    fl = long_be((uint32_t)(ori[1] & 0x0F) << 16);
+    fl += long_be((uint32_t)(ori[2] & 0xFF) << 8);
+    fl += long_be((uint32_t)(ori[3] & 0xFF));
 
     if (fl) {
         if (!dscp) { // Flow label carried in-line
             *iphc |= TF_ELIDED_DSCP;
-            *comp = ecn;
-            *(uint32_t *)comp |= long_be((uint32_t)(fl << 8));
+            comp[0] = (uint8_t)(ecn | (ori[1] & 0x0F));
+            comp[1] = ori[2];
+            comp[2] = ori[3];
             return 3;
         } else { // Traffic class and flow label carried in-line
             *iphc |= TF_INLINE;
             *comp = ecn | dscp;
-            *(uint32_t *)comp |= long_be(fl);
+            comp[1] = ori[1] & 0x0F;
+            comp[2] = ori[2];
+            comp[3] = ori[3];
             return 4;
         }
     } else if (ecn || dscp) { // Traffic class carried in-line
@@ -834,11 +838,11 @@ decompressor_nhc_udp(struct pico_frame *f, int32_t processed_len, int32_t *compr
             hdr->trans.dport = xF0B0 | short_be((uint16_t)(buf[1] & 0xff));
             *compressed_len = 2;
         } else if (UDP_COMPRESSED_SRC == compression) {
-            hdr->trans.dport = *(uint16_t *)&buf[2];
+            hdr->trans.dport = short_be((uint16_t)(((uint16_t)buf[2] << 8) | (uint16_t)buf[3]));
             hdr->trans.sport = xF000 | short_be((uint16_t)buf[1]);
             *compressed_len = 4;
         } else if (UDP_COMPRESSED_DST == compression) {
-            hdr->trans.sport = *(uint16_t *)&buf[1];
+            hdr->trans.sport = short_be((uint16_t)(((uint16_t)buf[1] << 8) | (uint16_t)buf[2]));
             hdr->trans.dport = xF000 | short_be((uint16_t)buf[3]);
             *compressed_len = 4;
         } else {
@@ -1265,10 +1269,10 @@ frag_update(struct pico_frame *f, struct frag_ctx *frag, uint8_t units, uint16_t
 static void
 frag_fill(uint8_t *frag, uint8_t dispatch, uint16_t dgram_size, uint16_t tag, uint8_t dgram_off, int32_t offset, uint16_t copy, uint16_t copied, uint8_t *buf)
 {
-    uint16_t x7FF = short_be(0x7FF);
-    frag[0] = dispatch;
-    *(uint16_t *)&frag[0] |= (uint16_t)(short_be(dgram_size) & x7FF);
-    *(uint16_t *)&frag[2] = (uint16_t)short_be(tag);
+    frag[0] = (uint8_t)(dispatch | ((uint8_t)short_be(dgram_size) & 0x07));
+    frag[1] = (uint8_t)(short_be(dgram_size) >> 8);
+    frag[2] = (uint8_t)(tag);
+    frag[3] = (uint8_t)(tag >> 8);
     frag[4] = (uint8_t)(dgram_off);
     buf_move(frag + offset, buf + copied, copy);
 }
@@ -1558,12 +1562,10 @@ defrag_update(struct frag_ctx *frag, uint16_t off, struct pico_frame *f)
 static struct frag_ctx *
 defrag_remove_header(struct pico_frame *f, uint16_t *dgram_size, uint16_t *tag, uint16_t *off, int32_t size)
 {
-    uint16_t x7FF = short_be(0x7FF);
-    uint16_t x00FF = short_be(0x00FF);
-    *dgram_size = short_be(*(uint16_t *)f->net_hdr & x7FF);
-    *tag = short_be(*(uint16_t *)&f->net_hdr[2]);
-    *off = short_be((uint16_t)(*(uint16_t *)&f->net_hdr[3] & x00FF));
-    *off = (uint16_t)(*off << 3);
+    *dgram_size = (uint16_t)(((uint16_t)(f->net_hdr[0] & 0x07) << 8) | (uint16_t)f->net_hdr[1]);
+    *tag = (uint16_t)(((uint16_t)f->net_hdr[2] << 8) | (uint16_t)f->net_hdr[3]);
+    *off = (uint16_t)((uint16_t)f->net_hdr[4] << 3);
+    dbg("RECV [0]: %02X [1]: %02X dgram_size: %d off: %d tag: %d\n", f->net_hdr[0], f->net_hdr[1], *dgram_size, *off, *tag);
     f->net_len = (uint16_t)(f->net_len - (uint16_t)size);
     f->len = (uint32_t)(f->len - (uint32_t)size);
     f->net_hdr += size;

--- a/modules/pico_6lowpan_ll.c
+++ b/modules/pico_6lowpan_ll.c
@@ -345,7 +345,7 @@ pico_6lowpan_ll_process_in(struct pico_protocol *self, struct pico_frame *f)
 int32_t pico_6lowpan_stack_recv(struct pico_device *dev, uint8_t *buffer, uint32_t len, union pico_ll_addr *src, union pico_ll_addr *dst)
 {
     int32_t ret = 0;
-    ll_dbg("Stack recv called!\n");
+    ll_dbg("6LoWPAN - Stack recv called!\n");
     if (PICO_DEV_IS_NOMAC(dev)) {
         struct pico_frame *f = pico_stack_recv_new_frame(dev, buffer, len);
         if (f) {

--- a/modules/pico_802154.c
+++ b/modules/pico_802154.c
@@ -388,7 +388,8 @@ addr_802154_iid(uint8_t iid[8], union pico_ll_addr *addr)
     struct pico_802154 pan = addr->pan;
 
     if (AM_6LOWPAN_SHORT == pan.mode) {
-        *(uint16_t *)&buf[6] = pan.addr._short.addr;
+        buf[6] = (uint8_t)(pan.addr._short.addr);
+        buf[7] = (uint8_t)(pan.addr._short.addr >> 8);
     } else if (AM_6LOWPAN_EXT == pan.mode) {
         memcpy(buf, pan.addr.data, SIZE_6LOWPAN_EXT);
         buf[0] ^= (uint8_t)0x02;
@@ -400,22 +401,44 @@ addr_802154_iid(uint8_t iid[8], union pico_ll_addr *addr)
     return 0;
 }
 
+/*
+ *  Allocates a pico_frame but makes sure the network-buffer starts on an 4-byte aligned address,
+ *  this is required by upper layer of the stack. IEEE802.15.4's header isn't necessarily 4/8-byte
+ *  aligned since the minimum size of an IEEE802.15.4 header is '5'. The datalink header therefore
+ *  might not (and most probably isn't) aligned on an aligned address. The datalink header will of
+ *  the size passed in 'headroom'
+ *
+ *  @param size         Size of the actual frame provided for network-layer and above
+ *  @param headroom     Size of the headroom for datalink-buffer
+ *  @param overhead     Size of the overhead to keep for the device driver
+ *
+ *  @return struct pico_frame *, returns the allocated frame upon success, 'NULL' otherwise.
+ */
+static struct pico_frame *
+pico_frame_alloc_with_headroom(uint16_t size, uint16_t headroom, uint16_t overhead)
+{
+    int network_offset = (((headroom + overhead) >> 3) + 1) << 3; // Sufficient headroom for alignment
+    struct pico_frame *f = pico_frame_alloc((uint32_t)(size + headroom + overhead));
+
+    if (!f)
+        return NULL;
+
+    f->net_hdr = f->buffer + network_offset;
+    f->datalink_hdr = f->net_hdr - headroom;
+    return f;
+}
+
 /* Allocates a frame with the maximum MAC header size + device's overhead-parameter since this is
  * the lowest level of the frame allocation chain */
 static struct pico_frame *
 pico_802154_frame_alloc(struct pico_device *dev, uint16_t size)
 {
-    struct pico_frame *f = pico_frame_alloc(dev->overhead + SIZE_802154_MHR_MAX + size);
-    uint32_t maclen = (uint32_t)size + SIZE_802154_MHR_MAX;
-    if (f) {
-        maclen = (uint32_t)(maclen / sizeof(uint32_t) * sizeof(uint32_t));
-        f->datalink_hdr = f->buffer + (int32_t)(f->buffer_len - maclen);
-        f->net_hdr = f->datalink_hdr + SIZE_802154_MHR_MAX;
-        f->dev = dev;
-        return f;
-    } else {
+    struct pico_frame *f = pico_frame_alloc_with_headroom(size, SIZE_802154_MHR_MAX, (uint16_t)dev->overhead);
+    if (!f)
         return NULL;
-    }
+
+    f->dev = dev;
+    return f;
 }
 
 const struct pico_6lowpan_ll_protocol pico_6lowpan_ll_802154 = {

--- a/modules/pico_802154.c
+++ b/modules/pico_802154.c
@@ -406,9 +406,11 @@ static struct pico_frame *
 pico_802154_frame_alloc(struct pico_device *dev, uint16_t size)
 {
     struct pico_frame *f = pico_frame_alloc(dev->overhead + SIZE_802154_MHR_MAX + size);
+    uint32_t maclen = (uint32_t)size + SIZE_802154_MHR_MAX;
     if (f) {
-        f->net_hdr = f->buffer + (int32_t)(f->buffer_len - (uint32_t)size);
-        f->datalink_hdr = f->net_hdr - SIZE_802154_MHR_MAX;
+        maclen = (uint32_t)(maclen / sizeof(uint32_t) * sizeof(uint32_t));
+        f->datalink_hdr = f->buffer + (int32_t)(f->buffer_len - maclen);
+        f->net_hdr = f->datalink_hdr + SIZE_802154_MHR_MAX;
         f->dev = dev;
         return f;
     } else {

--- a/modules/pico_dev_radio_mgr.c
+++ b/modules/pico_dev_radio_mgr.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <signal.h>
+#include <errno.h>
 
 #ifdef DEBUG_RADIOTEST
 #define RADIO_DBG       dbg
@@ -339,10 +340,11 @@ pico_radio_mgr_start(void)
         if (fds)
             PICO_FREE(fds);
         fds = pico_radio_mgr_socket_all((int *)&n);
-        ret = poll(fds, n, 1);
-        if (ret < 0) {
+        errno = 0;
+        ret = poll(fds, n, 0);
+        if (errno != EINTR && ret < 0) {
             RADIO_DBG("Socket error: %s\n", strerror(ret));
-            exit(255);
+            return ret;
         } else if (!ret) {
             continue;
         }

--- a/modules/pico_dev_radiotest.c
+++ b/modules/pico_dev_radiotest.c
@@ -114,9 +114,9 @@ static void radiotest_pcap_open(struct radiotest_radio *dev, char *dump)
     /* Open dump */
     dev->pcapd = pcap_dump_open(dev->pcap, path);
     if (dev->pcapd)
-        RADIO_DBG("PCAP Enabled\n");
+        dbg("PCAP Enabled\n");
     else
-        RADIO_DBG("PCAP Disabled\n");
+        dbg("PCAP Disabled\n");
 }
 
 static void radiotest_pcap_write(struct radiotest_radio *dev, uint8_t *buf, int len)
@@ -475,6 +475,7 @@ struct pico_device *pico_radiotest_create(uint8_t addr, uint8_t area0, uint8_t a
     }
 
     if (dump) {
+        dbg("Dump: %s\n", dump);
         radiotest_pcap_open(radio, dump);
     }
 

--- a/modules/pico_dev_radiotest.c
+++ b/modules/pico_dev_radiotest.c
@@ -27,6 +27,7 @@
 #include <arpa/inet.h>
 #include <sys/poll.h>
 #include <signal.h>
+#include <errno.h>
 
 #define LISTENING_PORT  7777
 #define MESSAGE_MTU     150
@@ -288,12 +289,13 @@ static int radiotest_poll(struct pico_device *dev, int loop_score)
     p.events = POLLIN | POLLHUP;
 
     /* Poll for data from radio management */
+    errno = 0;
     pollret = poll(&p, (nfds_t)1, 1);
-    if (pollret == 0)
+    if (errno == EINTR || pollret == 0)
         return loop_score;
 
-    if (pollret == -1) {
-        fprintf(stderr, "Socket error!\n");
+    if (pollret < 0) {
+        fprintf(stderr, "Socket error %s!\n", strerror(errno));
         exit(5);
     }
 
@@ -475,8 +477,8 @@ struct pico_device *pico_radiotest_create(uint8_t addr, uint8_t area0, uint8_t a
     }
 
     if (dump) {
-        dbg("Dump: %s\n", dump);
-        radiotest_pcap_open(radio, dump);
+ //       dbg("Dump: %s\n", dump);
+//        radiotest_pcap_open(radio, dump);
     }
 
     return (struct pico_device *)lp;

--- a/modules/pico_ipv6.c
+++ b/modules/pico_ipv6.c
@@ -397,15 +397,14 @@ int pico_ipv6_is_unspecified(const uint8_t addr[PICO_SIZE_IP6])
 
 static struct pico_ipv6_route *pico_ipv6_route_find(const struct pico_ip6 *addr)
 {
-    struct pico_ipv6_route *r = NULL;
     struct pico_tree_node *index = NULL;
+    struct pico_ipv6_route *r = NULL;
     int i = 0;
     if (!pico_ipv6_is_localhost(addr->addr) && (pico_ipv6_is_linklocal(addr->addr)  || pico_ipv6_is_sitelocal(addr->addr)))    {
         return NULL;
     }
 
-    pico_tree_foreach_reverse(index, &IPV6Routes)
-    {
+    pico_tree_foreach_reverse(index, &IPV6Routes) {
         r = index->keyValue;
         for (i = 0; i < PICO_SIZE_IP6; ++i) {
             if ((addr->addr[i] & (r->netmask.addr[i])) != ((r->dest.addr[i]) & (r->netmask.addr[i]))) {
@@ -1481,7 +1480,8 @@ static inline struct pico_ipv6_route *ipv6_route_add_link(struct pico_ip6 gatewa
 {
     struct pico_ip6 zerogateway = {{0}};
     struct pico_ipv6_route *r = pico_ipv6_route_find(&gateway);
-    if (!r ) { /* Specified Gateway is unreachable */
+
+    if (!r) { /* Specified Gateway is unreachable */
         pico_err = PICO_ERR_EHOSTUNREACH;
         return NULL;
     }
@@ -1490,7 +1490,6 @@ static inline struct pico_ipv6_route *ipv6_route_add_link(struct pico_ip6 gatewa
         pico_err = PICO_ERR_ENETUNREACH;
         return NULL;
     }
-
 
     return r;
 }
@@ -1508,7 +1507,7 @@ struct pico_ipv6_route *pico_ipv6_gateway_by_dev(struct pico_device *dev)
         if (!pico_ipv6_is_unspecified(route->gateway.addr) && pico_ipv6_is_unspecified(route->netmask.addr)) {
             /* Iterate over device's links */
             while (link) {
-                /* If link is equal to route's link, routing list is not empty */
+                /* If link is equal to route's link, router list is not empty */
                 if (0 == ipv6_link_compare(link, route->link))
                     return route;
                 link = pico_ipv6_link_by_dev_next(dev, link);
@@ -1559,6 +1558,7 @@ int pico_ipv6_route_add(struct pico_ip6 address, struct pico_ip6 netmask, struct
     test.netmask = netmask;
     test.metric = (uint32_t)metric;
     if (pico_tree_findKey(&IPV6Routes, &test)) {
+        /* Route already exists */
         pico_err = PICO_ERR_EINVAL;
         return -1;
     }

--- a/stack/pico_frame.c
+++ b/stack/pico_frame.c
@@ -64,7 +64,6 @@ struct pico_frame *pico_frame_copy(struct pico_frame *f)
     return new;
 }
 
-
 static struct pico_frame *pico_frame_do_alloc(uint32_t size, int zerocopy, int ext_buffer)
 {
     struct pico_frame *p = PICO_ZALLOC(sizeof(struct pico_frame));

--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -1076,17 +1076,20 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
     int ret = 0;
     (void)src;
 
-    if (msginfo)
+    if (msg_info) {
         dev = msginfo->dev;
-
+    }
 #ifdef PICO_SUPPORT_IPV6
-    if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
+    else if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
         dev = pico_ipv6_link_find(src);
         if(!dev) {
             return -1;
         }
     }
 #endif
+    else {
+        dev = get_sock_dev(s);
+    }
 
     f = pico_socket_frame_alloc(s, dev, (uint16_t)(len + hdr_offset));
     if (!f) {

--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -1076,7 +1076,7 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
     int ret = 0;
     (void)src;
 
-    if (msg_info) {
+    if (msginfo) {
         dev = msginfo->dev;
     }
 #ifdef PICO_SUPPORT_IPV6

--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -1082,13 +1082,14 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
 #ifdef PICO_SUPPORT_IPV6
     else if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
         dev = pico_ipv6_link_find(src);
-        if(!dev) {
-            return -1;
-        }
     }
 #endif
     else {
         dev = get_sock_dev(s);
+    }
+
+    if (!dev) {
+        return -1;
     }
 
     f = pico_socket_frame_alloc(s, dev, (uint16_t)(len + hdr_offset));

--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -1080,8 +1080,10 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
         dev = msginfo->dev;
     }
 #ifdef PICO_SUPPORT_IPV6
-    else if(IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
+    else if (IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
         dev = pico_ipv6_link_find(src);
+    } else if (ep) {
+        dev = pico_ipv6_source_dev_find(&ep->remote_addr.ip6);
     }
 #endif
     else {


### PR DESCRIPTION
There were still some issues with unaligned access, have to admit I completely overlooked that. I fixed them with the help of @adxlarbi a week or 2 ago. It should be sane to merge into development now.

@frederikvs, could you please especially verify the ```pico_socket_xmit_one```-function? I've altered some part of it so that the targeted interface (pico_device) is always derived from the destination address if it is passed in some way or another. But, I'm not entirely sure if I'm allowed to do that.. 