### PR TITLE
Allow for connection timeout to occur when socket is shutdown

### DIFF
--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -1937,7 +1937,14 @@ static void tcp_retrans_timeout(pico_time val, void *sock)
         if (tcp_retrans_timeout_check_queue(t) < 0)
             return;
     }
-    else if(t->backoff >= PICO_TCP_MAX_RETRANS && (t->sock.state & 0xFF00) == PICO_SOCKET_STATE_TCP_ESTABLISHED )
+    else if(t->backoff >= PICO_TCP_MAX_RETRANS &&
+            ((t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_ESTABLISHED ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_FIN_WAIT1 ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_FIN_WAIT2 ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_TIME_WAIT ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_CLOSE_WAIT ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_LAST_ACK ||
+             (t->sock.state & PICO_SOCKET_STATE_TCP) == PICO_SOCKET_STATE_TCP_CLOSING))
     {
         tcp_dbg("Connection timeout!\n");
         /* the retransmission timer, failed to get an ack for a frame, gives up on the connection */


### PR DESCRIPTION
When you locally or remotely close the TCP connection, so picoTCP has sent or received a FIN, the tcp socket goes out of the TCP-Established state. This allows the retransmission counter (**backoff**) of half closed sockets to stay eternally at the maximum retransmission count, never allowing the socket to be deleted if no communication is available.

Fix for #483.